### PR TITLE
Remove Niagara Falls from country mapping

### DIFF
--- a/pkg/txt/resources/countries.txt
+++ b/pkg/txt/resources/countries.txt
@@ -407,7 +407,6 @@ CA:Ottawa
 CA:Quebec
 CA:Ontario
 CA:Alberta
-CA:Niagara Falls
 IL:Israel
 IL:Holy Land
 EG:Egypt


### PR DESCRIPTION
The waterfalls are on a border, so they cannot be uniquely assigned to Canada (or USA).