### PR TITLE
Identify empty albums

### DIFF
--- a/frontend/src/options/options.js
+++ b/frontend/src/options/options.js
@@ -290,7 +290,6 @@ export const FoldersSortOrder = () => [
     text: $gettext("Random"),
     value: "random",
   },
-
 ];
 
 export const MapsAnimate = () => [

--- a/internal/entity/album.go
+++ b/internal/entity/album.go
@@ -244,6 +244,49 @@ func NewMonthAlbum(albumTitle, albumSlug string, year, month int) *Album {
 	return result
 }
 
+func FindLabelAlbums() (result Albums) {
+	// Both "label" and "country / year" album have the same album type,
+	// so to distinguish between the two we have few options:
+	// - "label" albums do not have a year
+	// - "label" albums do not have a country
+	// - "label" albums should contain the "label:" string as filter
+	if err := UnscopedDb().
+		Where("album_type = ?", AlbumMoment).
+		Where("album_year IS NULL").
+		Where("deleted_at IS NULL").
+		Find(&result).Error; err != nil {
+
+		log.Errorf("album: %s (not found)", err)
+		return nil
+	}
+
+	return result
+}
+
+func FindCountriesByYearAlbums() (result Albums) {
+	if err := UnscopedDb().
+		Where("album_type = ?", AlbumMoment).
+		Where("album_year IS NOT NULL").
+		Where("deleted_at IS NULL").
+		Find(&result).Error; err != nil {
+
+		log.Errorf("album: %s (not found)", err)
+		return nil
+	}
+
+	return result
+}
+
+// FindAlbumByType finds matching albums or returns nil.
+func FindAlbumsByType(albumType string) (result Albums) {
+	if err := UnscopedDb().Where("album_type = ? AND deleted_at IS NULL", albumType).Find(&result).Error; err != nil {
+		log.Errorf("album: %s (not found)", err)
+		return nil
+	}
+
+	return result
+}
+
 // FindAlbumBySlug finds a matching album or returns nil.
 func FindAlbumBySlug(albumSlug, albumType string) *Album {
 	result := Album{}

--- a/internal/photoprism/moments.go
+++ b/internal/photoprism/moments.go
@@ -12,6 +12,7 @@ import (
 	"github.com/photoprism/photoprism/internal/form"
 	"github.com/photoprism/photoprism/internal/mutex"
 	"github.com/photoprism/photoprism/internal/query"
+	"github.com/photoprism/photoprism/internal/search"
 	"github.com/photoprism/photoprism/pkg/txt"
 )
 
@@ -67,6 +68,11 @@ func (w *Moments) Start() (err error) {
 	if results, err := query.AlbumFolders(1); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
+		emptyAlbumbs := make(map[string]entity.Album)
+		for _, a := range entity.FindAlbumsByType(entity.AlbumFolder) {
+			emptyAlbumbs[a.AlbumUID] = a
+		}
+
 		for _, mom := range results {
 			f := form.PhotoSearch{
 				Path:   mom.Path,
@@ -74,6 +80,10 @@ func (w *Moments) Start() (err error) {
 			}
 
 			if a := entity.FindFolderAlbum(mom.Path); a != nil {
+				// mark the album as non-empty to prevent deletion
+				delete(emptyAlbumbs, a.AlbumUID)
+				log.Infof("moments: folder album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.FileCount)
+
 				if a.DeletedAt != nil {
 					// Nothing to do.
 					log.Tracef("moments: %s was deleted (%s)", txt.Quote(a.AlbumTitle), a.AlbumFilter)
@@ -95,14 +105,28 @@ func (w *Moments) Start() (err error) {
 				}
 			}
 		}
+
+		for _, album := range emptyAlbumbs {
+			log.Infof("moments: empty folder album %s will be deleted (%s)", txt.Quote(album.AlbumTitle), album.AlbumFilter)
+			album.Delete()
+		}
 	}
 
 	// All years and months.
 	if results, err := query.MomentsTime(1); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
+		emptyAlbumbs := make(map[string]entity.Album)
+		for _, a := range entity.FindAlbumsByType(entity.AlbumMonth) {
+			emptyAlbumbs[a.AlbumUID] = a
+		}
+
 		for _, mom := range results {
 			if a := entity.FindAlbumBySlug(mom.Slug(), entity.AlbumMonth); a != nil {
+				// mark the album as non-empty to prevent deletion
+				delete(emptyAlbumbs, a.AlbumUID)
+				log.Infof("moments: month album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.PhotoCount)
+
 				if !a.Deleted() {
 					log.Tracef("moments: %s already exists (%s)", txt.Quote(a.AlbumTitle), a.AlbumFilter)
 				} else if err := a.Restore(); err != nil {
@@ -118,12 +142,22 @@ func (w *Moments) Start() (err error) {
 				}
 			}
 		}
+
+		for _, album := range emptyAlbumbs {
+			log.Infof("moments: empty month album %s will be deleted (%s)", txt.Quote(album.AlbumTitle), album.AlbumFilter)
+			album.Delete()
+		}
 	}
 
 	// Countries by year.
 	if results, err := query.MomentsCountriesByYear(threshold); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
+		emptyAlbumbs := make(map[string]entity.Album)
+		for _, a := range entity.FindCountriesByYearAlbums() {
+			emptyAlbumbs[a.AlbumUID] = a
+		}
+
 		for _, mom := range results {
 			f := form.PhotoSearch{
 				Country: mom.Country,
@@ -132,7 +166,11 @@ func (w *Moments) Start() (err error) {
 			}
 
 			if a := entity.FindAlbumBySlug(mom.Slug(), entity.AlbumMoment); a != nil {
-				if a.DeletedAt != nil {
+				// mark the album as non-empty to prevent deletion
+				delete(emptyAlbumbs, a.AlbumUID)
+				log.Infof("moments: moment album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.PhotoCount)
+
+				if a.Deleted() {
 					// Nothing to do.
 					log.Tracef("moments: %s was deleted (%s)", txt.Quote(a.AlbumTitle), a.AlbumFilter)
 				} else {
@@ -149,12 +187,21 @@ func (w *Moments) Start() (err error) {
 				}
 			}
 		}
+
+		for _, album := range emptyAlbumbs {
+			deleteAlbumIfEmpty(album)
+		}
 	}
 
 	// Countries totals.
 	if results, err := query.MomentsCountries(threshold); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
+		emptyAlbumbs := make(map[string]entity.Album)
+		for _, a := range entity.FindAlbumsByType(entity.AlbumCountry) {
+			emptyAlbumbs[a.AlbumUID] = a
+		}
+
 		for _, mom := range results {
 			f := form.PhotoSearch{
 				Country: mom.Country,
@@ -162,7 +209,11 @@ func (w *Moments) Start() (err error) {
 			}
 
 			if a := entity.FindAlbumBySlug(mom.Slug(), entity.AlbumCountry); a != nil {
-				if a.DeletedAt != nil {
+				// mark the album as non-empty to prevent deletion
+				delete(emptyAlbumbs, a.AlbumUID)
+				log.Infof("moments: country album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.PhotoCount)
+
+				if a.Deleted() {
 					// Nothing to do.
 					log.Tracef("moments: %s was deleted (%s)", txt.Quote(a.AlbumTitle), a.AlbumFilter)
 				} else {
@@ -178,12 +229,21 @@ func (w *Moments) Start() (err error) {
 				}
 			}
 		}
+
+		for _, album := range emptyAlbumbs {
+			deleteAlbumIfEmpty(album)
+		}
 	}
 
 	// States and countries.
 	if results, err := query.MomentsStates(1); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
+		emptyAlbumbs := make(map[string]entity.Album)
+		for _, a := range entity.FindAlbumsByType(entity.AlbumState) {
+			emptyAlbumbs[a.AlbumUID] = a
+		}
+
 		for _, mom := range results {
 			f := form.PhotoSearch{
 				Country: mom.Country,
@@ -192,7 +252,11 @@ func (w *Moments) Start() (err error) {
 			}
 
 			if a := entity.FindAlbumBySlug(mom.Slug(), entity.AlbumState); a != nil {
-				if a.DeletedAt != nil {
+				// mark the album as non-empty to prevent deletion
+				delete(emptyAlbumbs, a.AlbumUID)
+				log.Infof("moments: state album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.PhotoCount)
+
+				if a.Deleted() {
 					// Nothing to do.
 					log.Tracef("moments: %s was deleted (%s)", txt.Quote(a.AlbumTitle), a.AlbumFilter)
 				} else {
@@ -208,12 +272,22 @@ func (w *Moments) Start() (err error) {
 				}
 			}
 		}
+
+		for _, album := range emptyAlbumbs {
+			log.Infof("moments: empty state album %s will be deleted (%s)", txt.Quote(album.AlbumTitle), album.AlbumFilter)
+			album.Delete()
+		}
 	}
 
 	// Popular labels.
 	if results, err := query.MomentsLabels(threshold); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
+		emptyAlbumbs := make(map[string]entity.Album)
+		for _, a := range entity.FindLabelAlbums() {
+			emptyAlbumbs[a.AlbumUID] = a
+		}
+
 		for _, mom := range results {
 			f := form.PhotoSearch{
 				Label:  mom.Label,
@@ -222,6 +296,10 @@ func (w *Moments) Start() (err error) {
 
 			if a := entity.FindAlbumBySlug(mom.Slug(), entity.AlbumMoment); a != nil {
 				log.Tracef("moments: %s already exists (%s)", txt.Quote(mom.Title()), f.Serialize())
+
+				// mark the album as non-empty to prevent deletion
+				delete(emptyAlbumbs, a.AlbumUID)
+				log.Infof("moments: label album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.PhotoCount)
 
 				if f.Serialize() == a.AlbumFilter || a.DeletedAt != nil {
 					// Nothing to do.
@@ -251,6 +329,10 @@ func (w *Moments) Start() (err error) {
 				log.Errorf("moments: failed to create new moment %s (%s)", mom.Title(), f.Serialize())
 			}
 		}
+
+		for _, album := range emptyAlbumbs {
+			deleteAlbumIfEmpty(album)
+		}
 	}
 
 	if err := query.UpdateFolderDates(); err != nil {
@@ -273,4 +355,26 @@ func (w *Moments) Start() (err error) {
 // Cancel stops the current operation.
 func (w *Moments) Cancel() {
 	mutex.MainWorker.Cancel()
+}
+
+func deleteAlbumIfEmpty(album entity.Album) {
+	// The threshold will naturaly rise when people upload more photos, so all of a sudden some
+	// albums might be considered empty if they drop below the dynamic threshold. To prevent that
+	// we can check whether the albums that have dynamic thresholds are truly empty.
+	f := form.PhotoSearch{
+		Filter: album.AlbumFilter,
+	}
+
+	if err := f.ParseQueryString(); err != nil {
+		log.Errorf("moments: %s (deserialize photo query for album %s)", err, txt.Quote(album.AlbumTitle))
+	} else {
+		if _, count, err := search.Photos(f); err != nil {
+			log.Errorf("moments: %s (photo search for album %s)", err, txt.Quote(album.AlbumTitle))
+		} else if count > 0 {
+			log.Infof("moments: moment album %s is below threshold, but will not be deleted", txt.Quote(album.AlbumTitle))
+		} else if count == 0 {
+			log.Infof("moments: empty moment album %s will be deleted (%s)", txt.Quote(album.AlbumTitle), album.AlbumFilter)
+			album.Delete()
+		}
+	}
 }

--- a/internal/photoprism/moments.go
+++ b/internal/photoprism/moments.go
@@ -374,7 +374,8 @@ func deleteAlbumIfEmpty(album entity.Album) {
 			log.Infof("moments: moment album %s is below threshold, but will not be deleted", txt.Quote(album.AlbumTitle))
 		} else if count == 0 {
 			log.Infof("moments: empty moment album %s will be deleted (%s)", txt.Quote(album.AlbumTitle), album.AlbumFilter)
-			album.Delete()
+			log.Warn("moments: album deletion is running in dry-run mode, so the album will not be deleted yet")
+			// album.Delete()
 		}
 	}
 }


### PR DESCRIPTION
related to https://github.com/photoprism/photoprism/issues/1456

Identify which albums/moments are empty and can be deleted. Do not delete them yet, so that the implementation can be evaluated on larger photo collections first.