### PR TITLE
Use the correct default sort order for folder entities

### DIFF
--- a/internal/api/folder.go
+++ b/internal/api/folder.go
@@ -44,6 +44,9 @@ func GetFolders(router *gin.RouterGroup, urlPath, rootName, rootPath string) {
 			return
 		}
 
+		conf := service.Config()
+		foldersSortOrder := conf.Settings().Folders.SortOrder
+
 		cache := service.FolderCache()
 		recursive := f.Recursive
 		listFiles := f.Files
@@ -64,7 +67,7 @@ func GetFolders(router *gin.RouterGroup, urlPath, rootName, rootPath string) {
 			}
 		}
 
-		if folders, err := query.FoldersByPath(rootName, rootPath, path, recursive); err != nil {
+		if folders, err := query.FoldersByPath(rootName, rootPath, path, recursive, foldersSortOrder); err != nil {
 			log.Errorf("folder: %s", err)
 			c.JSON(http.StatusOK, resp)
 			return

--- a/internal/entity/folder.go
+++ b/internal/entity/folder.go
@@ -53,7 +53,7 @@ func (m *Folder) BeforeCreate(scope *gorm.Scope) error {
 }
 
 // NewFolder creates a new file system directory entity.
-func NewFolder(root, pathName string, modTime time.Time) Folder {
+func NewFolder(root, pathName string, modTime time.Time, order string) Folder {
 	now := TimeStamp()
 
 	pathName = strings.Trim(pathName, string(os.PathSeparator))
@@ -75,7 +75,7 @@ func NewFolder(root, pathName string, modTime time.Time) Folder {
 		Root:          root,
 		Path:          pathName,
 		FolderType:    TypeDefault,
-		FolderOrder:   SortOrderName,
+		FolderOrder:   order,
 		FolderCountry: UnknownCountry.ID,
 		FolderYear:    year,
 		FolderMonth:   month,
@@ -170,7 +170,7 @@ func (m *Folder) Create() error {
 		} else if err := a.UpdateFolder(m.Path, f.Serialize()); err != nil {
 			log.Errorf("folder: %s (update album)", err.Error())
 		}
-	} else if a := NewFolderAlbum(m.Title(), m.Path, f.Serialize(), f.Order); a != nil {
+	} else if a := NewFolderAlbum(m.Title(), m.Path, f.Serialize(), m.FolderOrder); a != nil {
 		a.AlbumYear = m.FolderYear
 		a.AlbumMonth = m.FolderMonth
 		a.AlbumDay = m.FolderDay

--- a/internal/entity/folder_test.go
+++ b/internal/entity/folder_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewFolder(t *testing.T) {
 	t.Run("2020/05", func(t *testing.T) {
-		folder := NewFolder(RootOriginals, "2020/05", time.Now().UTC())
+		folder := NewFolder(RootOriginals, "2020/05", time.Now().UTC(), SortOrderName)
 		assert.Equal(t, RootOriginals, folder.Root)
 		assert.Equal(t, "2020/05", folder.Path)
 		assert.Equal(t, "May 2020", folder.FolderTitle)
@@ -28,7 +28,7 @@ func TestNewFolder(t *testing.T) {
 	})
 
 	t.Run("/2020/05/01/", func(t *testing.T) {
-		folder := NewFolder(RootOriginals, "/2020/05/01/", time.Now().UTC())
+		folder := NewFolder(RootOriginals, "/2020/05/01/", time.Now().UTC(), "")
 		assert.Equal(t, "2020/05/01", folder.Path)
 		assert.Equal(t, "May 2020", folder.FolderTitle)
 		assert.Equal(t, 2020, folder.FolderYear)
@@ -37,7 +37,7 @@ func TestNewFolder(t *testing.T) {
 	})
 
 	t.Run("/2020/05/23/", func(t *testing.T) {
-		folder := NewFolder(RootImport, "/2020/05/23/", time.Now().UTC())
+		folder := NewFolder(RootImport, "/2020/05/23/", time.Now().UTC(), "")
 		assert.Equal(t, "2020/05/23", folder.Path)
 		assert.Equal(t, "May 23, 2020", folder.FolderTitle)
 		assert.Equal(t, 2020, folder.FolderYear)
@@ -46,7 +46,7 @@ func TestNewFolder(t *testing.T) {
 	})
 
 	t.Run("/2020/05/23/Iceland 2020", func(t *testing.T) {
-		folder := NewFolder(RootOriginals, "/2020/05/23/Iceland 2020", time.Now().UTC())
+		folder := NewFolder(RootOriginals, "/2020/05/23/Iceland 2020", time.Now().UTC(), "")
 		assert.Equal(t, "2020/05/23/Iceland 2020", folder.Path)
 		assert.Equal(t, "Iceland 2020", folder.FolderTitle)
 		assert.Equal(t, 2020, folder.FolderYear)
@@ -55,7 +55,7 @@ func TestNewFolder(t *testing.T) {
 	})
 
 	t.Run("/London/2020/05/23", func(t *testing.T) {
-		folder := NewFolder(RootOriginals, "/London/2020/05/23", time.Now().UTC())
+		folder := NewFolder(RootOriginals, "/London/2020/05/23", time.Now().UTC(), "")
 		assert.Equal(t, "London/2020/05/23", folder.Path)
 		assert.Equal(t, "May 23, 2020", folder.FolderTitle)
 		assert.Equal(t, 2020, folder.FolderYear)
@@ -64,7 +64,7 @@ func TestNewFolder(t *testing.T) {
 	})
 
 	t.Run("empty", func(t *testing.T) {
-		folder := NewFolder(RootOriginals, "", time.Time{})
+		folder := NewFolder(RootOriginals, "", time.Time{}, "")
 		assert.Equal(t, "", folder.Path)
 		assert.Equal(t, "Originals", folder.FolderTitle)
 		assert.Equal(t, 0, folder.FolderYear)
@@ -73,7 +73,7 @@ func TestNewFolder(t *testing.T) {
 	})
 
 	t.Run("root", func(t *testing.T) {
-		folder := NewFolder(RootOriginals, RootPath, time.Time{})
+		folder := NewFolder(RootOriginals, RootPath, time.Time{}, "")
 		assert.Equal(t, "", folder.Path)
 		assert.Equal(t, "Originals", folder.FolderTitle)
 		assert.Equal(t, 0, folder.FolderYear)
@@ -82,13 +82,13 @@ func TestNewFolder(t *testing.T) {
 	})
 
 	t.Run("pathName equals root path", func(t *testing.T) {
-		folder := NewFolder("", RootPath, time.Now().UTC())
+		folder := NewFolder("", RootPath, time.Now().UTC(), "")
 		assert.Equal(t, "", folder.Path)
 	})
 }
 
 func TestFirstOrCreateFolder(t *testing.T) {
-	folder := NewFolder(RootOriginals, RootPath, time.Now().UTC())
+	folder := NewFolder(RootOriginals, RootPath, time.Now().UTC(), "")
 	result := FirstOrCreateFolder(&folder)
 
 	if result == nil {
@@ -120,7 +120,7 @@ func TestFirstOrCreateFolder(t *testing.T) {
 
 func TestFolder_SetValuesFromPath(t *testing.T) {
 	t.Run("/", func(t *testing.T) {
-		folder := NewFolder("new", "", time.Now().UTC())
+		folder := NewFolder("new", "", time.Now().UTC(), "")
 		folder.SetValuesFromPath()
 		assert.Equal(t, "New", folder.FolderTitle)
 	})
@@ -157,18 +157,20 @@ func TestFindFolder(t *testing.T) {
 
 func TestFolder_Updates(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		folder := NewFolder("oldRoot", "oldPath", time.Now().UTC())
+		folder := NewFolder("oldRoot", "oldPath", time.Now().UTC(), SortOrderNewest)
 
 		assert.Equal(t, "oldRoot", folder.Root)
 		assert.Equal(t, "oldPath", folder.Path)
+		assert.Equal(t, SortOrderNewest, folder.FolderOrder)
 
-		err := folder.Updates(Folder{Root: "newRoot", Path: "newPath"})
+		err := folder.Updates(Folder{Root: "newRoot", Path: "newPath", FolderOrder: SortOrderRandom})
 
 		if err != nil {
 			t.Fatal(err)
 		}
 		assert.Equal(t, "newRoot", folder.Root)
 		assert.Equal(t, "newPath", folder.Path)
+		assert.Equal(t, SortOrderRandom, folder.FolderOrder)
 	})
 }
 
@@ -178,11 +180,12 @@ func TestFolder_SetForm(t *testing.T) {
 
 		folderForm, err := form.NewFolder(formValues)
 
-		folder := NewFolder("oldRoot", "oldPath", time.Now().UTC())
+		folder := NewFolder("oldRoot", "oldPath", time.Now().UTC(), SortOrderAdded)
 
 		assert.Equal(t, "oldRoot", folder.Root)
 		assert.Equal(t, "oldPath", folder.Path)
 		assert.Equal(t, "OldPath", folder.FolderTitle)
+		assert.Equal(t, SortOrderAdded, folder.FolderOrder)
 
 		err = folder.SetForm(folderForm)
 

--- a/internal/photoprism/import.go
+++ b/internal/photoprism/import.go
@@ -49,6 +49,11 @@ func (imp *Import) thumbPath() string {
 	return imp.conf.ThumbPath()
 }
 
+// foldersSortOrder returns the configured default sort order for folders
+func (imp *Import) foldersSortOrder() string {
+	return imp.conf.Settings().Folders.SortOrder
+}
+
 // Start imports media files from a directory and converts/indexes them as needed.
 func (imp *Import) Start(opt ImportOptions) fs.Done {
 	defer func() {
@@ -142,7 +147,7 @@ func (imp *Import) Start(opt ImportOptions) fs.Done {
 						directories = append(directories, fileName)
 					}
 
-					folder := entity.NewFolder(entity.RootImport, fs.RelName(fileName, imp.conf.ImportPath()), fs.BirthTime(fileName))
+					folder := entity.NewFolder(entity.RootImport, fs.RelName(fileName, imp.conf.ImportPath()), fs.BirthTime(fileName), imp.foldersSortOrder())
 
 					if err := folder.Create(); err == nil {
 						log.Infof("import: added folder /%s", folder.Path)

--- a/internal/photoprism/import_worker.go
+++ b/internal/photoprism/import_worker.go
@@ -64,7 +64,7 @@ func ImportWorker(jobs <-chan ImportJob) {
 				} else {
 					destDirRel := fs.RelName(destDir, imp.originalsPath())
 
-					folder := entity.NewFolder(entity.RootOriginals, destDirRel, fs.BirthTime(destDir))
+					folder := entity.NewFolder(entity.RootOriginals, destDirRel, fs.BirthTime(destDir), imp.foldersSortOrder())
 
 					if err := folder.Create(); err == nil {
 						log.Infof("import: created folder /%s", folder.Path)

--- a/internal/photoprism/index.go
+++ b/internal/photoprism/index.go
@@ -65,6 +65,11 @@ func (ind *Index) thumbPath() string {
 	return ind.conf.ThumbPath()
 }
 
+// foldersSortOrder returns the configured default sort order for folders
+func (ind *Index) foldersSortOrder() string {
+	return ind.conf.Settings().Folders.SortOrder
+}
+
 // Cancel stops the current indexing operation.
 func (ind *Index) Cancel() {
 	mutex.MainWorker.Cancel()
@@ -152,7 +157,7 @@ func (ind *Index) Start(opt IndexOptions) fs.Done {
 
 			if skip, result := fs.SkipWalk(fileName, isDir, isSymlink, done, ignore); skip {
 				if (isSymlink || isDir) && result != filepath.SkipDir {
-					folder := entity.NewFolder(entity.RootOriginals, relName, fs.BirthTime(fileName))
+					folder := entity.NewFolder(entity.RootOriginals, relName, fs.BirthTime(fileName), ind.foldersSortOrder())
 
 					if err := folder.Create(); err == nil {
 						log.Infof("index: added folder /%s", folder.Path)

--- a/internal/photoprism/moments.go
+++ b/internal/photoprism/moments.go
@@ -92,7 +92,7 @@ func (w *Moments) Start() (err error) {
 				} else {
 					log.Tracef("moments: %s already exists (%s)", txt.Quote(a.AlbumTitle), a.AlbumFilter)
 				}
-			} else if a := entity.NewFolderAlbum(mom.Title(), mom.Path, f.Serialize(), conf.Settings().Folders.SortOrder); a != nil {
+			} else if a := entity.NewFolderAlbum(mom.Title(), mom.Path, f.Serialize(), w.conf.Settings().Folders.SortOrder); a != nil {
 				a.AlbumYear = mom.FolderYear
 				a.AlbumMonth = mom.FolderMonth
 				a.AlbumDay = mom.FolderDay

--- a/internal/query/folders.go
+++ b/internal/query/folders.go
@@ -9,7 +9,7 @@ import (
 )
 
 // FoldersByPath returns a slice of folders in a given directory incl sub directories in recursive mode.
-func FoldersByPath(rootName, rootPath, path string, recursive bool) (folders entity.Folders, err error) {
+func FoldersByPath(rootName, rootPath, path string, recursive bool, defaultSortOrder string) (folders entity.Folders, err error) {
 	dirs, err := fs.Dirs(filepath.Join(rootPath, path), recursive, true)
 
 	if err != nil {
@@ -19,7 +19,7 @@ func FoldersByPath(rootName, rootPath, path string, recursive bool) (folders ent
 	folders = make(entity.Folders, len(dirs))
 
 	for i, dir := range dirs {
-		newFolder := entity.NewFolder(rootName, filepath.Join(path, dir), fs.BirthTime(filepath.Join(rootPath, dir)))
+		newFolder := entity.NewFolder(rootName, filepath.Join(path, dir), fs.BirthTime(filepath.Join(rootPath, dir)), defaultSortOrder)
 
 		if err := newFolder.Create(); err == nil {
 			folders[i] = newFolder

--- a/internal/query/folders_test.go
+++ b/internal/query/folders_test.go
@@ -30,7 +30,7 @@ func TestFolderCoverByUID(t *testing.T) {
 
 func TestFoldersByPath(t *testing.T) {
 	t.Run("root", func(t *testing.T) {
-		folders, err := FoldersByPath(entity.RootOriginals, "testdata", "", false)
+		folders, err := FoldersByPath(entity.RootOriginals, "testdata", "", false, "")
 
 		t.Logf("folders: %+v", folders)
 
@@ -42,7 +42,7 @@ func TestFoldersByPath(t *testing.T) {
 	})
 
 	t.Run("subdirectory", func(t *testing.T) {
-		folders, err := FoldersByPath(entity.RootOriginals, "testdata", "directory", false)
+		folders, err := FoldersByPath(entity.RootOriginals, "testdata", "directory", false, "")
 
 		t.Logf("folders: %+v", folders)
 


### PR DESCRIPTION
follow up of https://github.com/kvalev/photoprism/pull/21

The `folder` album entities had the correct sort order, but the folder entities didn't, which lead to an incorrect sort order in certain cases (when a `folder` album was derived from the folder entity).