### PR TITLE
Rework moments deletion and restoration

### DIFF
--- a/frontend/src/component/album/clipboard.vue
+++ b/frontend/src/component/album/clipboard.vue
@@ -109,7 +109,7 @@ export default {
   },
   data() {
     return {
-      deletable: ["album", "moment", "state"],
+      deletable: ["album"],
       features: this.$config.settings().features,
       expanded: false,
       dialog: {

--- a/internal/entity/album.go
+++ b/internal/entity/album.go
@@ -244,6 +244,7 @@ func NewMonthAlbum(albumTitle, albumSlug string, year, month int) *Album {
 	return result
 }
 
+// FindLabelAlbums finds all label albums (including deletes ones) or returns nil.
 func FindLabelAlbums() (result Albums) {
 	// Both "label" and "country / year" album have the same album type,
 	// so to distinguish between the two we have few options:
@@ -253,7 +254,6 @@ func FindLabelAlbums() (result Albums) {
 	if err := UnscopedDb().
 		Where("album_type = ?", AlbumMoment).
 		Where("album_year IS NULL").
-		Where("deleted_at IS NULL").
 		Find(&result).Error; err != nil {
 
 		log.Errorf("album: %s (not found)", err)
@@ -263,11 +263,11 @@ func FindLabelAlbums() (result Albums) {
 	return result
 }
 
+// FindCountriesByYearAlbums finds all moment albums (including deleted ones) or returns nil.
 func FindCountriesByYearAlbums() (result Albums) {
 	if err := UnscopedDb().
 		Where("album_type = ?", AlbumMoment).
 		Where("album_year IS NOT NULL").
-		Where("deleted_at IS NULL").
 		Find(&result).Error; err != nil {
 
 		log.Errorf("album: %s (not found)", err)
@@ -277,9 +277,9 @@ func FindCountriesByYearAlbums() (result Albums) {
 	return result
 }
 
-// FindAlbumByType finds matching albums or returns nil.
+// FindAlbumByType finds all albums (including deleted ones) with the given type or returns nil.
 func FindAlbumsByType(albumType string) (result Albums) {
-	if err := UnscopedDb().Where("album_type = ? AND deleted_at IS NULL", albumType).Find(&result).Error; err != nil {
+	if err := UnscopedDb().Where("album_type = ?", albumType).Find(&result).Error; err != nil {
 		log.Errorf("album: %s (not found)", err)
 		return nil
 	}

--- a/internal/photoprism/moments.go
+++ b/internal/photoprism/moments.go
@@ -68,9 +68,9 @@ func (w *Moments) Start() (err error) {
 	if results, err := query.AlbumFolders(1); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
-		emptyAlbumbs := make(map[string]entity.Album)
+		emptyAlbums := make(map[string]entity.Album)
 		for _, a := range entity.FindAlbumsByType(entity.AlbumFolder) {
-			emptyAlbumbs[a.AlbumUID] = a
+			emptyAlbums[a.AlbumUID] = a
 		}
 
 		for _, mom := range results {
@@ -80,8 +80,8 @@ func (w *Moments) Start() (err error) {
 			}
 
 			if a := entity.FindFolderAlbum(mom.Path); a != nil {
-				// mark the album as non-empty to prevent deletion
-				delete(emptyAlbumbs, a.AlbumUID)
+				// Mark the album as non-empty to prevent deletion.
+				delete(emptyAlbums, a.AlbumUID)
 				log.Infof("moments: folder album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.FileCount)
 
 				if a.DeletedAt != nil {
@@ -106,9 +106,8 @@ func (w *Moments) Start() (err error) {
 			}
 		}
 
-		for _, album := range emptyAlbumbs {
-			log.Infof("moments: empty folder album %s will be deleted (%s)", txt.Quote(album.AlbumTitle), album.AlbumFilter)
-			album.Delete()
+		for _, album := range emptyAlbums {
+			deleteAlbumIfEmpty(album)
 		}
 	}
 
@@ -116,15 +115,15 @@ func (w *Moments) Start() (err error) {
 	if results, err := query.MomentsTime(1); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
-		emptyAlbumbs := make(map[string]entity.Album)
+		emptyAlbums := make(map[string]entity.Album)
 		for _, a := range entity.FindAlbumsByType(entity.AlbumMonth) {
-			emptyAlbumbs[a.AlbumUID] = a
+			emptyAlbums[a.AlbumUID] = a
 		}
 
 		for _, mom := range results {
 			if a := entity.FindAlbumBySlug(mom.Slug(), entity.AlbumMonth); a != nil {
-				// mark the album as non-empty to prevent deletion
-				delete(emptyAlbumbs, a.AlbumUID)
+				// Mark the album as non-empty to prevent deletion.
+				delete(emptyAlbums, a.AlbumUID)
 				log.Infof("moments: month album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.PhotoCount)
 
 				if !a.Deleted() {
@@ -143,9 +142,8 @@ func (w *Moments) Start() (err error) {
 			}
 		}
 
-		for _, album := range emptyAlbumbs {
-			log.Infof("moments: empty month album %s will be deleted (%s)", txt.Quote(album.AlbumTitle), album.AlbumFilter)
-			album.Delete()
+		for _, album := range emptyAlbums {
+			deleteAlbumIfEmpty(album)
 		}
 	}
 
@@ -153,9 +151,9 @@ func (w *Moments) Start() (err error) {
 	if results, err := query.MomentsCountriesByYear(threshold); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
-		emptyAlbumbs := make(map[string]entity.Album)
+		emptyAlbums := make(map[string]entity.Album)
 		for _, a := range entity.FindCountriesByYearAlbums() {
-			emptyAlbumbs[a.AlbumUID] = a
+			emptyAlbums[a.AlbumUID] = a
 		}
 
 		for _, mom := range results {
@@ -166,8 +164,8 @@ func (w *Moments) Start() (err error) {
 			}
 
 			if a := entity.FindAlbumBySlug(mom.Slug(), entity.AlbumMoment); a != nil {
-				// mark the album as non-empty to prevent deletion
-				delete(emptyAlbumbs, a.AlbumUID)
+				// Mark the album as non-empty to prevent deletion.
+				delete(emptyAlbums, a.AlbumUID)
 				log.Infof("moments: moment album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.PhotoCount)
 
 				if a.Deleted() {
@@ -188,7 +186,7 @@ func (w *Moments) Start() (err error) {
 			}
 		}
 
-		for _, album := range emptyAlbumbs {
+		for _, album := range emptyAlbums {
 			deleteAlbumIfEmpty(album)
 		}
 	}
@@ -197,9 +195,9 @@ func (w *Moments) Start() (err error) {
 	if results, err := query.MomentsCountries(threshold); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
-		emptyAlbumbs := make(map[string]entity.Album)
+		emptyAlbums := make(map[string]entity.Album)
 		for _, a := range entity.FindAlbumsByType(entity.AlbumCountry) {
-			emptyAlbumbs[a.AlbumUID] = a
+			emptyAlbums[a.AlbumUID] = a
 		}
 
 		for _, mom := range results {
@@ -209,8 +207,8 @@ func (w *Moments) Start() (err error) {
 			}
 
 			if a := entity.FindAlbumBySlug(mom.Slug(), entity.AlbumCountry); a != nil {
-				// mark the album as non-empty to prevent deletion
-				delete(emptyAlbumbs, a.AlbumUID)
+				// Mark the album as non-empty to prevent deletion.
+				delete(emptyAlbums, a.AlbumUID)
 				log.Infof("moments: country album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.PhotoCount)
 
 				if a.Deleted() {
@@ -230,7 +228,7 @@ func (w *Moments) Start() (err error) {
 			}
 		}
 
-		for _, album := range emptyAlbumbs {
+		for _, album := range emptyAlbums {
 			deleteAlbumIfEmpty(album)
 		}
 	}
@@ -239,9 +237,9 @@ func (w *Moments) Start() (err error) {
 	if results, err := query.MomentsStates(1); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
-		emptyAlbumbs := make(map[string]entity.Album)
+		emptyAlbums := make(map[string]entity.Album)
 		for _, a := range entity.FindAlbumsByType(entity.AlbumState) {
-			emptyAlbumbs[a.AlbumUID] = a
+			emptyAlbums[a.AlbumUID] = a
 		}
 
 		for _, mom := range results {
@@ -252,8 +250,8 @@ func (w *Moments) Start() (err error) {
 			}
 
 			if a := entity.FindAlbumBySlug(mom.Slug(), entity.AlbumState); a != nil {
-				// mark the album as non-empty to prevent deletion
-				delete(emptyAlbumbs, a.AlbumUID)
+				// Mark the album as non-empty to prevent deletion.
+				delete(emptyAlbums, a.AlbumUID)
 				log.Infof("moments: state album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.PhotoCount)
 
 				if a.Deleted() {
@@ -273,9 +271,8 @@ func (w *Moments) Start() (err error) {
 			}
 		}
 
-		for _, album := range emptyAlbumbs {
-			log.Infof("moments: empty state album %s will be deleted (%s)", txt.Quote(album.AlbumTitle), album.AlbumFilter)
-			album.Delete()
+		for _, album := range emptyAlbums {
+			deleteAlbumIfEmpty(album)
 		}
 	}
 
@@ -283,9 +280,9 @@ func (w *Moments) Start() (err error) {
 	if results, err := query.MomentsLabels(threshold); err != nil {
 		log.Errorf("moments: %s", err.Error())
 	} else {
-		emptyAlbumbs := make(map[string]entity.Album)
+		emptyAlbums := make(map[string]entity.Album)
 		for _, a := range entity.FindLabelAlbums() {
-			emptyAlbumbs[a.AlbumUID] = a
+			emptyAlbums[a.AlbumUID] = a
 		}
 
 		for _, mom := range results {
@@ -297,8 +294,8 @@ func (w *Moments) Start() (err error) {
 			if a := entity.FindAlbumBySlug(mom.Slug(), entity.AlbumMoment); a != nil {
 				log.Tracef("moments: %s already exists (%s)", txt.Quote(mom.Title()), f.Serialize())
 
-				// mark the album as non-empty to prevent deletion
-				delete(emptyAlbumbs, a.AlbumUID)
+				// Mark the album as non-empty to prevent deletion.
+				delete(emptyAlbums, a.AlbumUID)
 				log.Infof("moments: label album %s is not empty, has %d photos", txt.Quote(a.AlbumTitle), mom.PhotoCount)
 
 				if f.Serialize() == a.AlbumFilter || a.DeletedAt != nil {
@@ -330,7 +327,7 @@ func (w *Moments) Start() (err error) {
 			}
 		}
 
-		for _, album := range emptyAlbumbs {
+		for _, album := range emptyAlbums {
 			deleteAlbumIfEmpty(album)
 		}
 	}
@@ -371,9 +368,9 @@ func deleteAlbumIfEmpty(album entity.Album) {
 		if _, count, err := search.Photos(f); err != nil {
 			log.Errorf("moments: %s (photo search for album %s)", err, txt.Quote(album.AlbumTitle))
 		} else if count > 0 {
-			log.Infof("moments: moment album %s is below threshold, but will not be deleted", txt.Quote(album.AlbumTitle))
+			log.Infof("moments: %s album %s is below threshold, but will not be deleted", album.AlbumType, txt.Quote(album.AlbumTitle))
 		} else if count == 0 {
-			log.Infof("moments: empty moment album %s will be deleted (%s)", txt.Quote(album.AlbumTitle), album.AlbumFilter)
+			log.Infof("moments: empty %s album %s will be deleted (%s)", album.AlbumType, txt.Quote(album.AlbumTitle), album.AlbumFilter)
 			log.Warn("moments: album deletion is running in dry-run mode, so the album will not be deleted yet")
 			// album.Delete()
 		}

--- a/internal/query/albums.go
+++ b/internal/query/albums.go
@@ -7,7 +7,6 @@ import (
 	"github.com/photoprism/photoprism/internal/form"
 	"github.com/photoprism/photoprism/internal/mutex"
 	"github.com/photoprism/photoprism/internal/search"
-	"github.com/photoprism/photoprism/pkg/txt"
 )
 
 // Albums returns a slice of albums.
@@ -43,15 +42,6 @@ func AlbumCoverByUID(uid string) (file entity.File, err error) {
 				} else {
 					return file, nil
 				}
-			}
-		}
-
-		// Automatically hide empty months.
-		if a.AlbumType == entity.AlbumMonth {
-			if err := a.Delete(); err != nil {
-				log.Errorf("album: %s (hide %s)", err, a.AlbumType)
-			} else {
-				log.Infof("album: %s hidden", txt.Quote(a.AlbumTitle))
 			}
 		}
 


### PR DESCRIPTION
The lifecycle of all automatically created albums (such as `moment`, `state`, `country`) should be managed internally by photoprism. Meaning when an album becomes empty (due to changing photo metadata such as date and location), it should be automatically deleted and in case an empty album gets filled with photos (e.g. photos were uploaded to an initially empty folder), it should be restored automatically.