### PR TITLE
Correct country count

### DIFF
--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -389,11 +389,6 @@ func (c *Config) UserConfig() ClientConfig {
 		Take(&result.Count)
 
 	c.Db().
-		Table("countries").
-		Select("(COUNT(*) - 1) AS countries").
-		Take(&result.Count)
-
-	c.Db().
 		Table("places").
 		Select("SUM(photo_count > 0) AS places").
 		Where("id <> 'zz'").


### PR DESCRIPTION
The number of countries should be determined by the detected country albums. This way the number shown in the UI is consistent with the number of albums.