### PR TITLE
Create a preview image when pushing to the preview branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,12 @@ on:
   release:
     types:
       - published
+  push:
+    branches:
+      - preview
 
 env:
-  TAG: ${{ github.event.release.tag_name }}
+  TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || 'preview' }}
   DOCKER_REPO: kvalev/photoprism
 
 jobs:


### PR DESCRIPTION
Sources:
- [Poor man's ternary operator](https://github.com/actions/runner/issues/409#issuecomment-752775072)
- [Determine event type for a GitHub action](https://stackoverflow.com/questions/59052527/how-do-i-get-the-event-type-that-triggered-a-github-action)