### PR TITLE
Remove state mapping for France métropolitaine

### DIFF
--- a/pkg/txt/states.go
+++ b/pkg/txt/states.go
@@ -120,7 +120,7 @@ var StatesDE = LookupTable{
 
 // StatesFR maps common abbreviations for French states.
 var StatesFR = LookupTable{
-	"France métropolitaine": "Île-de-France",
+	"France métropolitaine": "",
 }
 
 // StatesNZ maps common abbreviations for provinces and territories in New Zealand.


### PR DESCRIPTION
Similarly to `AUS`, it should be mapped to an empty string to denote that there is no correct state mapping.