### PR TITLE
Added Web Share API to photo viewer and clipboard

### DIFF
--- a/frontend/src/common/util.js
+++ b/frontend/src/common/util.js
@@ -146,6 +146,13 @@ export default class Util {
     start = now;
   }
 
+  static JSFileFromPhoto(blob, photo) {
+    return new File([blob], photo.Name.replaceAll("/", "-"), {
+      type: photo.Mime,
+      lastModified: photo.ModTime,
+    });
+  }
+
   static async copyToMachineClipboard(text) {
     if (window.navigator.clipboard) {
       await window.navigator.clipboard.writeText(text);

--- a/frontend/src/component/photo/clipboard.vue
+++ b/frontend/src/component/photo/clipboard.vue
@@ -316,9 +316,6 @@ export default {
 
       this.expanded = false;
     },
-    onWebShare(path) {
-      console.log(path);
-    },
     edit() {
       // Open Edit Dialog
       Event.PubSub.publish("dialog.edit", {selection: this.selection, album: this.album, index: 0});

--- a/frontend/src/component/photo/clipboard.vue
+++ b/frontend/src/component/photo/clipboard.vue
@@ -34,6 +34,19 @@
           <v-icon>cloud</v-icon>
         </v-btn>
 
+        
+        <v-btn
+            v-if="context !== 'archive' && context !== 'review' && navigatorCanShare" fab dark
+            small
+            :title="$gettext('Share')"
+            color="share"
+            :disabled="selection.length === 0"
+            class="action-webshare"
+            @click.stop="webShare()"
+        >
+          <v-icon>share</v-icon>
+        </v-btn>
+
         <v-btn
             v-if="context === 'review'" fab dark
             small
@@ -154,6 +167,7 @@
 </template>
 <script>
 import Api from "common/api";
+import Util from "common/util";
 import Notify from "common/notify";
 import Event from "pubsub-js";
 import download from "common/download";
@@ -173,6 +187,7 @@ export default {
       features: this.$config.settings().features,
       expanded: false,
       isAlbum: this.album && this.album.Type === 'album',
+      navigatorCanShare: navigator.canShare,
       dialog: {
         archive: false,
         delete: false,
@@ -273,6 +288,36 @@ export default {
     },
     onDownload(path) {
       download(path, "photos.zip");
+    },
+    webShare() {
+      switch (this.selection.length) {
+        case 0: return;
+        case 1: new Photo().find(this.selection[0]).then(p => p.webShare()); break;
+        default:
+          // Resolve selection into Photo objects and download them as blobs
+          const photos = this.selection.map((uid) => new Photo().find(uid).then((p) => fetch(p.getDownloadUrl()).then((res) => res.blob()).then((blob) => {
+            p.Blob = blob;
+            return p;
+          })));
+          // Wait for all downloads, then open native browser share dialog
+          Promise.all(photos).then((blobs) => {
+            const filesArray = blobs.map((p) => Util.JSFileFromPhoto(p.Blob, p.mainFile()));
+            const shareData = {
+              files: filesArray,
+            };
+            return navigator.share(shareData);
+          }).catch((e) => {
+            this.$notify.error(this.$gettext("sharing photos failed"));
+            console.warn(e);
+          })
+      }
+
+      Notify.success(this.$gettext("Downloading & Sharing…"));
+
+      this.expanded = false;
+    },
+    onWebShare(path) {
+      console.log(path);
     },
     edit() {
       // Open Edit Dialog

--- a/frontend/src/component/photo/viewer.vue
+++ b/frontend/src/component/photo/viewer.vue
@@ -22,6 +22,11 @@
             <v-icon size="16" color="white">get_app</v-icon>
           </button>
 
+          <button v-if="navigatorCanShare" class="pswp__button action-webshare" style="background: none;"
+                  :title="$gettext('Share')" @click.exact="onWebShare">
+            <v-icon size="16" color="white">share</v-icon>
+          </button>
+          
           <button class="pswp__button action-edit hidden-shared-only" style="background: none;" :title="$gettext('Edit')"
                   @click.exact="onEdit">
             <v-icon size="16" color="white">edit</v-icon>
@@ -98,6 +103,7 @@ export default {
     return {
       selection: this.$clipboard.selection,
       config: this.$config.values,
+      navigatorCanShare: navigator.canShare,
       item: new Thumb(),
       subscriptions: [],
       interval: false,
@@ -244,6 +250,21 @@ export default {
       Notify.success(this.$gettext("Downloading…"));
 
       new Photo().find(this.item.uid).then(p => p.downloadAll());
+    },
+    onWebShare() {
+      this.onPause();
+
+      if (!this.item || !this.item.download_url) {
+        console.warn("photo viewer: no download url");
+        return;
+      }
+
+      new Photo().find(this.item.uid).then(p => p.webShare()).catch(e => {
+        this.$notify.error("couldn't share photo");
+        console.warn(e);
+      });
+
+      Notify.success(this.$gettext("Downloading & Sharing…"));
     },
     onEdit() {
       this.onPause();

--- a/frontend/src/model/photo.js
+++ b/frontend/src/model/photo.js
@@ -892,6 +892,7 @@ export class Photo extends RestModel {
         const filesArray = [Util.JSFileFromPhoto(blob, this.mainFile())];
         const shareData = {
           files: filesArray,
+          title: this.getTitle(),
         };
         return navigator.share(shareData);
       });

--- a/frontend/src/model/photo.js
+++ b/frontend/src/model/photo.js
@@ -884,6 +884,19 @@ export class Photo extends RestModel {
     });
   }
 
+  webShare() {
+    // Fetches the photo in the browser and opens the native share dialog
+    return fetch(this.getDownloadUrl())
+      .then((res) => res.blob())
+      .then((blob) => {
+        const filesArray = [Util.JSFileFromPhoto(blob, this.mainFile())];
+        const shareData = {
+          files: filesArray,
+        };
+        return navigator.share(shareData);
+      });
+  }
+
   static batchSize() {
     return 60;
   }


### PR DESCRIPTION
Author: https://github.com/photoprism/photoprism/pull/1792

![photoprism_webshare](https://user-images.githubusercontent.com/3762829/144905075-eb56f0e0-886b-4452-abee-5e9299cb74a3.gif)

This PR adds share buttons using the [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Share_API) in browsers that support it. Basically, it opens the native Share menu on mobile devices and some desktop browsers, letting users share / edit / mail photos from the PWA as you would from a native photo gallery app.

I built this after watching someone struggle to share a photo from the PhotoPrism PWA on Android with a friend on WhatsApp.

* It works alongside the existing sharing features, which may be a bit confusing, but at least there are different icons

* It works from the photo viewer toolbar, and from the photo clipboard after selecting one or more photos

* I left the share button in the album toolbar alone, I think it makes more sense to share URLs to albums instead of downloading and sharing all the files

* I had a bit of a name collision between the JS `File` and your model, so I broke that part of the code out into `common/util`. Let me know if there's a better way to do that

* I tested it on Windows in Edge, Chrome and Firefox (where it's not supported and doesn't show up by design), but couldn't test on my mobile devices since Web Share requires HTTPS and I couldn't get that set up between my dev environment and my phone

* AFAIK there's no easy way to cover this with automated testcases, so I didn't write any
