### PR TITLE
Show number of photos for folders

### DIFF
--- a/frontend/src/pages/albums.vue
+++ b/frontend/src/pages/albums.vue
@@ -157,7 +157,12 @@
                   </button>
                 </div>
 
-                <div v-else-if="album.Type === 'album'" class="caption mb-2">
+                <div v-if="album.Type === 'folder'" class="caption mb-2">
+                  <button @click.exact="edit(album)">
+                    /{{ album.Path | truncate(100) }}
+                  </button>
+                </div>
+                <div v-if="['album', 'folder'].includes(album.Type)" class="caption mb-2">
                   <button v-if="album.PhotoCount === 1" @click.exact="edit(album)">
                     <translate>Contains one picture.</translate>
                   </button>
@@ -166,11 +171,6 @@
                   </button>
                   <button v-else @click.stop.prevent="$router.push({name: 'browse'})">
                     <translate>Add pictures from search results by selecting them.</translate>
-                  </button>
-                </div>
-                <div v-else-if="album.Type === 'folder'" class="caption mb-2">
-                  <button @click.exact="edit(album)">
-                    /{{ album.Path | truncate(100) }}
                   </button>
                 </div>
                 <div v-if="album.Category !== ''" class="caption mb-2 d-inline-block">


### PR DESCRIPTION
The photo_count part of the existing query had to be rewritten. The respective
SQL query is:

```sql
SELECT a.album_title, a.album_path, COUNT(p.id) AS photo_count
FROM albums a
LEFT JOIN photos p on a.album_path = p.photo_path
WHERE a.album_type = "folder" and a.deleted_at IS NULL
GROUP BY a.album_uid
```

related to https://github.com/photoprism/photoprism/issues/923