### PR TITLE
Bugfix for face regions with an odd size

### DIFF
--- a/frontend/src/dialog/people/select-face.vue
+++ b/frontend/src/dialog/people/select-face.vue
@@ -42,11 +42,13 @@ export default {
   data() {
     return {
       coordinates: null,
+      image: null,
     };
   },
   methods: {
-    onChange({coordinates}) {
+    onChange({coordinates, image}) {
       this.coordinates = coordinates;
+      this.image = image;
     },
     cancel() {
       this.$emit('cancel');
@@ -56,8 +58,8 @@ export default {
       const half_size = parseInt(size / 2);
 
       const face = {
-        cols: this.file.Width,
-        rows: this.file.Height,
+        cols: this.file.Width, // or this.image.width
+        rows: this.file.Height, // or this.image.height
         score: 0,
         face: {
           name: "face",

--- a/frontend/src/dialog/people/select-face.vue
+++ b/frontend/src/dialog/people/select-face.vue
@@ -53,6 +53,7 @@ export default {
     },
     confirm() {
       const size = this.coordinates.width;
+      const half_size = parseInt(size / 2);
 
       const face = {
         cols: this.file.Width,
@@ -61,8 +62,8 @@ export default {
         face: {
           name: "face",
           size: size,
-          x: this.coordinates.top + size / 2,
-          y: this.coordinates.left + size / 2,
+          x: this.coordinates.top + half_size,
+          y: this.coordinates.left + half_size,
         },
       };
 


### PR DESCRIPTION
The backend expects the face coordinates to be integers, which was not the case when the selected face region had an odd size (due to a division by 2). This PR fixes the problem and showcases an alternative way to retrieve the dimensions of the image.

follow up of #51 