### PR TITLE
Show photo count for country, state and month albums

### DIFF
--- a/frontend/src/pages/albums.vue
+++ b/frontend/src/pages/albums.vue
@@ -166,7 +166,7 @@
                     /{{ album.Path | truncate(100) }}
                   </button>
                 </div>
-                <div v-if="['album', 'folder'].includes(album.Type)" class="caption mb-2">
+                <div v-if="['album', 'country', 'folder', 'month', 'state'].includes(album.Type)" class="caption mb-2">
                   <button v-if="album.PhotoCount === 1" @click.exact="edit(album)">
                     <translate>Contains one picture.</translate>
                   </button>

--- a/internal/search/albums.go
+++ b/internal/search/albums.go
@@ -23,12 +23,31 @@ func Albums(f form.SearchAlbums) (results AlbumResults, err error) {
 		Where("albums.deleted_at IS NULL")
 
 	// Set photo counts for non-"album" albums.
-	if f.Type == entity.AlbumFolder {
+	switch f.Type {
+	case entity.AlbumFolder:
 		s = s.
 			// Rewrite the select statement to calculate the photo count based on the photo/album path.
 			Select("albums.*, COUNT(p.id) as photo_count, cl.link_count, CASE WHEN albums.album_year = 0 THEN 0 ELSE 1 END AS has_year").
 			Joins("LEFT JOIN photos p on albums.album_path = p.photo_path").
-			Group("album_uid");
+			Group("album_uid")
+	case entity.AlbumCountry:
+		s = s.
+			// Rewrite the select statement to calculate the photo count based on the photo/album country.
+			Select("albums.*, COUNT(p.id) as photo_count, cl.link_count, CASE WHEN albums.album_year = 0 THEN 0 ELSE 1 END AS has_year").
+			Joins("LEFT JOIN photos p on albums.album_country = p.photo_country").
+			Group("album_uid")
+	case entity.AlbumState:
+		s = s.
+			// Rewrite the select statement to calculate the photo count based on the photo/album state.
+			Select("albums.*, COUNT(p.id) as photo_count, cl.link_count, CASE WHEN albums.album_year = 0 THEN 0 ELSE 1 END AS has_year").
+			Joins("LEFT JOIN (SELECT places.place_state, photos.* FROM `photos` LEFT JOIN places ON photos.place_id = places.id) p on albums.album_state = p.place_state").
+			Group("album_uid")
+	case entity.AlbumMonth:
+		s = s.
+			// Rewrite the select statement to calculate the photo count based on the photo/album year and month.
+			Select("albums.*, COUNT(p.id) as photo_count, cl.link_count, CASE WHEN albums.album_year = 0 THEN 0 ELSE 1 END AS has_year").
+			Joins("LEFT JOIN photos p on albums.album_year = p.photo_year AND albums.album_month = p.photo_month").
+			Group("album_uid")
 	}
 
 	// Limit result count.


### PR DESCRIPTION
Show the photo count for most of the native smart albums - country, state and month/calendar. This is done similarly to #50.