### PR TITLE
Import face region metadata

### DIFF
--- a/internal/entity/file.go
+++ b/internal/entity/file.go
@@ -757,6 +757,21 @@ func (m *File) AddFace(f face.Face, subjUid string) {
 	}
 }
 
+// HasFace checks whether the file already contains a marker for the given face.
+func (m *File) HasFace(f face.Face) bool {
+	// Create new marker from face.
+	marker := NewFaceMarker(f, *m, "")
+
+	// Failed creating new marker?
+	if marker == nil {
+		log.Errorf("markers: failed creating new marker")
+		return false
+	}
+
+	// Check if marker overlaps with existing markers.
+	return m.Markers().Contains(*marker)
+}
+
 // ValidFaceCount returns the number of valid face markers.
 func (m *File) ValidFaceCount() (c int) {
 	return ValidFaceCount(m.FileUID)

--- a/internal/entity/file.go
+++ b/internal/entity/file.go
@@ -740,7 +740,7 @@ func (m *File) AddFaces(faces face.Faces) {
 func (m *File) AddFace(f face.Face, subjUid string) (*Marker, error) {
 	// Only add faces with exactly one embedding so that they can be compared and clustered.
 	if !f.Embeddings.One() {
-		return nil, fmt.Errorf("file does not have exactly one embedding, has %d", f.Embeddings.Count())
+		return nil, fmt.Errorf("face does not have exactly one embedding, has %d", f.Embeddings.Count())
 	}
 
 	// Create new marker from face.

--- a/internal/entity/file.go
+++ b/internal/entity/file.go
@@ -761,19 +761,18 @@ func (m *File) AddFace(f face.Face, subjUid string) (*Marker, error) {
 	return nil, nil
 }
 
-// HasFace checks whether the file already contains a marker for the given face.
-func (m *File) HasFace(f face.Face) bool {
+// FindFaceMarker checks whether the file already contains a marker for the given face and returns it if it does.
+func (m *File) FindFaceMarker(f face.Face) (*Marker, error) {
 	// Create new marker from face.
 	marker := NewFaceMarker(f, *m, "")
 
 	// Failed creating new marker?
 	if marker == nil {
-		log.Errorf("file %s: failed creating new marker", clean.Log(m.FileUID))
-		return false
+		return nil, fmt.Errorf("failed creating marker when searching for face marker")
 	}
 
-	// Check if marker overlaps with existing markers.
-	return m.Markers().Contains(*marker)
+	// Check if marker overlaps with existing markers and return it.
+	return m.Markers().Find(*marker), nil
 }
 
 // ValidFaceCount returns the number of valid face markers.

--- a/internal/entity/markers.go
+++ b/internal/entity/markers.go
@@ -54,6 +54,17 @@ func (m Markers) Contains(other Marker) bool {
 	return false
 }
 
+// Find checks whether a marker at the same position already exists and returns it if ot does, otherwise it returns nil.
+func (m Markers) Find(other Marker) *Marker {
+	for i := range m {
+		if m[i].OverlapPercent(other) > face.OverlapThreshold {
+			return &m[i]
+		}
+	}
+
+	return nil
+}
+
 // DetectedFaceCount returns the number of automatically detected face markers.
 func (m Markers) DetectedFaceCount() (count int) {
 	for i := range m {

--- a/internal/face/face.go
+++ b/internal/face/face.go
@@ -26,9 +26,11 @@ package face
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/photoprism/photoprism/internal/crop"
 	"github.com/photoprism/photoprism/internal/event"
+	"github.com/photoprism/photoprism/pkg/txt"
 )
 
 var log = event.Log
@@ -42,6 +44,11 @@ type Face struct {
 	Eyes       Areas      `json:"eyes,omitempty"`
 	Landmarks  Areas      `json:"landmarks,omitempty"`
 	Embeddings Embeddings `json:"embeddings,omitempty"`
+}
+
+// String returns the face name and landmark position as string.
+func (f Face) String() string {
+	return fmt.Sprintf("%s-%s", txt.Slug(f.Area.Name), f.Area)
 }
 
 // Size returns the absolute face size in pixels.

--- a/internal/face/faces.go
+++ b/internal/face/faces.go
@@ -21,6 +21,15 @@ func (faces *Faces) Append(f Face) {
 	*faces = append(*faces, f)
 }
 
+// AppendIfNotContains adds all faces that do not conflict with existing ones.
+func (faces *Faces) AppendIfNotContains(others ...Face) {
+	for _, other := range others {
+		if !faces.Contains(other) {
+			faces.Append(other)
+		}
+	}
+}
+
 // Count returns the number of faces detected.
 func (faces Faces) Count() int {
 	return len(faces)

--- a/internal/meta/data.go
+++ b/internal/meta/data.go
@@ -76,6 +76,10 @@ type Data struct {
 	MicroVideo        bool             `meta:"MicroVideo"`
 	MicroVideoVersion int              `meta:"MicroVideoVersion"`
 	MicroVideoOffset  int              `meta:"MicroVideoOffset"`
+
+	// New, face region related properties
+	Regions   []Region   `meta:"RegionInfo"`
+	RegionsMP []RegionMP `meta:"RegionInfoMP"`
 }
 
 // DirectoryEntry represents the "Directory" exif metadata type.
@@ -84,6 +88,28 @@ type DirectoryEntry struct {
 	Semantic string
 	Length   int
 	Padding  int
+}
+
+// Region represents a face region in MWG format.
+type Region struct {
+	Area Area
+	Name string
+	Type string
+}
+
+// Area describes the face area in MWG format.
+type Area struct {
+	H    float32
+	W    float32
+	X    float32 // face center
+	Y    float32 // face center
+	Unit string
+}
+
+// RegionMP represents a face region in WLPG format.
+type RegionMP struct {
+	PersonDisplayName string
+	Rectangle         string
 }
 
 // New returns a new metadata struct.

--- a/internal/meta/data.go
+++ b/internal/meta/data.go
@@ -78,8 +78,9 @@ type Data struct {
 	MicroVideoOffset  int              `meta:"MicroVideoOffset"`
 
 	// New, face region related properties
-	Regions   []Region   `meta:"RegionInfo"`
-	RegionsMP []RegionMP `meta:"RegionInfoMP"`
+	Regions     []Region     `meta:"RegionInfo"`
+	RegionsIPTC []RegionIPTC `meta:"ImageRegion"`
+	RegionsMP   []RegionMP   `meta:"RegionInfoMP"`
 }
 
 // DirectoryEntry represents the "Directory" exif metadata type.
@@ -104,6 +105,21 @@ type Area struct {
 	X    float32 // face center
 	Y    float32 // face center
 	Unit string
+}
+
+type RegionIPTC struct {
+	Person   []string `json:"PersonInImage"`
+	Boundary Boundary `json:"RegionBoundary"`
+}
+
+type Boundary struct {
+	Shape string  `json:"RbShape"`
+	Unit  string  `json:"RbUnit"`
+	H     float64 `json:"RbH"`
+	W     float64 `json:"RbW"`
+	X     float64 `json:"RbX"`
+	Y     float64 `json:"RbY"`
+	Rx    float64 `json:"RbRx"`
 }
 
 // RegionMP represents a face region in WLPG format.

--- a/internal/meta/data.go
+++ b/internal/meta/data.go
@@ -108,11 +108,14 @@ type Area struct {
 	Unit string
 }
 
+// RegionIPTC represents a face region in IPTC format.
 type RegionIPTC struct {
 	Person   []string `json:"PersonInImage"`
 	Boundary Boundary `json:"RegionBoundary"`
 }
 
+// Boundary describes an IPTC face region shape.
+// All coordinates are relative to the image's orientation.
 type Boundary struct {
 	Shape string  `json:"RbShape"`
 	Unit  string  `json:"RbUnit"`
@@ -124,6 +127,7 @@ type Boundary struct {
 }
 
 // RegionMP represents a face region in WLPG format.
+// All coordinates are relative to the image's orientation.
 type RegionMP struct {
 	PersonDisplayName string
 	Rectangle         string

--- a/internal/meta/data.go
+++ b/internal/meta/data.go
@@ -99,11 +99,12 @@ type Region struct {
 }
 
 // Area describes the face area in MWG format.
+// All coordinates are relative to the image's orientation.
 type Area struct {
-	H    float32
-	W    float32
-	X    float32 // face center
-	Y    float32 // face center
+	H    float64 // face height
+	W    float64 // face width
+	X    float64 // face center
+	Y    float64 // face center
 	Unit string
 }
 

--- a/internal/meta/json_exiftool.go
+++ b/internal/meta/json_exiftool.go
@@ -175,6 +175,16 @@ func (data *Data) Exiftool(jsonData []byte, originalName string) (err error) {
 				}
 
 				fieldValue.Set(reflect.ValueOf(entries))
+			case []Region:
+				regions := []Region{}
+				json.Unmarshal([]byte(jsonValue.Get("RegionList").Raw), &regions)
+
+				fieldValue.Set(reflect.ValueOf(regions))
+			case []RegionMP:
+				regions := []RegionMP{}
+				json.Unmarshal([]byte(jsonValue.Get("Regions").Raw), &regions)
+
+				fieldValue.Set(reflect.ValueOf(regions))
 			default:
 				log.Warnf("metadata: cannot assign value of type %s to %s (exiftool)", t, tagValue)
 			}

--- a/internal/meta/json_exiftool.go
+++ b/internal/meta/json_exiftool.go
@@ -180,6 +180,11 @@ func (data *Data) Exiftool(jsonData []byte, originalName string) (err error) {
 				json.Unmarshal([]byte(jsonValue.Get("RegionList").Raw), &regions)
 
 				fieldValue.Set(reflect.ValueOf(regions))
+			case []RegionIPTC:
+				regions := []RegionIPTC{}
+				json.Unmarshal([]byte(jsonValue.Raw), &regions)
+
+				fieldValue.Set(reflect.ValueOf(regions))
 			case []RegionMP:
 				regions := []RegionMP{}
 				json.Unmarshal([]byte(jsonValue.Get("Regions").Raw), &regions)

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -331,9 +331,10 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 		return result
 	} else if ind.findFaces && file.FilePrimary {
 		if m.HasFaces() {
-			log.Debugf("index: found face region metadata in %s (%s)", logName, m.Faces())
+			faces := m.Faces()
+			log.Debugf("index: found face region metadata in %s (%s)", logName, faces)
 
-			for _, f := range m.Faces() {
+			for _, f := range faces {
 				log.Debugf("index: processing face region %s", f)
 
 				if file.HasFace(f) {
@@ -356,7 +357,7 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 				// Check that we have only one embedding. This duplicates the check in AddFace, but it's important
 				// to have it here as well, so that we can report the error.
 				if !embeddings.One() {
-					log.Errorf("index: unexpected embeddings count %d for face region crop area %s and file %s", embeddings.Count(), f.CropArea(), logName)
+					log.Errorf("index: unexpected embeddings count %d for face region %s and file %s", embeddings.Count(), f, logName)
 					continue
 				}
 

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -12,7 +12,6 @@ import (
 	"github.com/photoprism/photoprism/internal/classify"
 	"github.com/photoprism/photoprism/internal/entity"
 	"github.com/photoprism/photoprism/internal/event"
-	"github.com/photoprism/photoprism/internal/face"
 	"github.com/photoprism/photoprism/internal/meta"
 	"github.com/photoprism/photoprism/internal/query"
 	"github.com/photoprism/photoprism/pkg/clean"
@@ -342,9 +341,9 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 					continue
 				}
 
-				// Calculate the face score, which is usually done by facenet.
-				f.Score = int(face.QualityThreshold(f.Area.Scale))
-				log.Debugf("index: calculated face score %d", f.Score)
+				// Hardcode the face score, which is usually computed by facenet.
+				// Setting a higher score (>15), will mean that the face region will be used for clustering.
+				f.Score = 1
 
 				// Calculate the embeddings vector for the given face region.
 				embeddings, err := ind.faceNet.Embeddings(FileName(file.FileRoot, file.FileName), f)

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -329,6 +329,10 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 		result.Status = IndexSkipped
 		return result
 	} else if ind.findFaces && file.FilePrimary {
+		if m.HasFaces() {
+			log.Debugf("faces: found face region metadata %v", m.Faces())
+		}
+
 		if markers := file.Markers(); markers != nil {
 			// Detect faces.
 			faces := ind.Faces(m, markers.DetectedFaceCount())

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -383,6 +383,10 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 						log.Errorf("index: could not create marker for file %s and face %s - possible bug", clean.Log(file.FileUID), f)
 						continue
 					}
+
+					// Set the source for face region markers to 'meta' to be able to distinguish from
+					// detected markers, which have the 'image' source.
+					marker.MarkerSrc = entity.SrcMeta
 				}
 
 				name := f.Area.Name

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -336,6 +336,11 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 			for _, f := range m.Faces() {
 				log.Debugf("index: processing face region %s", f)
 
+				if file.HasFace(f) {
+					log.Debugf("index: face region was already indexed %s", f)
+					continue
+				}
+
 				// Calculate the face score, which is usually done by facenet.
 				f.Score = int(face.QualityThreshold(f.Area.Scale))
 				log.Debugf("index: calculated face score %d", f.Score)

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -336,42 +336,53 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 			for _, f := range faces {
 				log.Debugf("index: processing face region %s", f)
 
-				if file.HasFace(f) {
-					log.Debugf("index: face region was already indexed %s", f)
-					continue
-				}
-
-				// Hardcode the face score, which is usually computed by facenet.
-				// Setting a higher score (>15), will mean that the face region will be used for clustering.
-				f.Score = 1
-
-				// Calculate the embeddings vector for the given face region.
-				embeddings, err := ind.faceNet.Embeddings(FileName(file.FileRoot, file.FileName), f)
+				marker, err := file.FindFaceMarker(f)
 
 				if err != nil {
-					log.Errorf("index: %s (calculating embeddings for %s)", err, logName)
+					log.Errorf("index: %s (searching for face marker)", err)
 					continue
 				}
 
-				// Check that we have only one embedding. This duplicates the check in AddFace, but it's important
-				// to have it here as well, so that we can report the error.
-				if !embeddings.One() {
-					log.Errorf("index: unexpected embeddings count %d for face region %s and file %s", embeddings.Count(), f, logName)
-					continue
-				}
+				if marker != nil {
+					if marker.SubjectName() != "" {
+						log.Debugf("index: face region was already indexed %s", f)
+						continue
+					} else {
+						log.Debugf("index: face region was indexed, but was not named %s", f)
+					}
+				} else {
+					// Hardcode the face score, which is usually computed by facenet.
+					// Setting a higher score (>15), will mean that the face region will be used for clustering.
+					f.Score = 1
 
-				// Assign the embeddings to the face and add the face to the file, which will create a new marker.
-				f.Embeddings = embeddings
-				marker, err := file.AddFace(f, "")
+					// Calculate the embeddings vector for the given face region.
+					embeddings, err := ind.faceNet.Embeddings(FileName(file.FileRoot, file.FileName), f)
 
-				if err != nil {
-					log.Errorf("index: %s (adding face %s to file %s)", err, f, clean.Log(file.FileUID))
-					continue
-				}
+					if err != nil {
+						log.Errorf("index: %s (calculating embeddings for %s)", err, logName)
+						continue
+					}
 
-				if marker == nil {
-					log.Errorf("index: could not create marker for file %s and face %s - possible bug", clean.Log(file.FileUID), f)
-					continue
+					// Check that we have only one embedding. This duplicates the check in AddFace, but it's important
+					// to have it here as well, so that we can report the error.
+					if !embeddings.One() {
+						log.Errorf("index: unexpected embeddings count %d for face region %s and file %s", embeddings.Count(), f, logName)
+						continue
+					}
+
+					// Assign the embeddings to the face and add the face to the file, which will create a new marker.
+					f.Embeddings = embeddings
+					marker, err = file.AddFace(f, "")
+
+					if err != nil {
+						log.Errorf("index: %s (adding face %s to file %s)", err, f, clean.Log(file.FileUID))
+						continue
+					}
+
+					if marker == nil {
+						log.Errorf("index: could not create marker for file %s and face %s - possible bug", clean.Log(file.FileUID), f)
+						continue
+					}
 				}
 
 				name := f.Area.Name

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -363,13 +363,6 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 						continue
 					}
 
-					// Check that we have only one embedding. This duplicates the check in AddFace, but it's important
-					// to have it here as well, so that we can report the error.
-					if !embeddings.One() {
-						log.Errorf("index: unexpected embeddings count %d for face region %s and file %s", embeddings.Count(), f, logName)
-						continue
-					}
-
 					// Assign the embeddings to the face and add the face to the file, which will create a new marker.
 					f.Embeddings = embeddings
 					marker, err = file.AddFace(f, "")

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -331,10 +331,10 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 		return result
 	} else if ind.findFaces && file.FilePrimary {
 		if m.HasFaces() {
-			log.Debugf("index: found face region metadata in %s (%#v)", logName, m.Faces())
+			log.Debugf("index: found face region metadata in %s (%s)", logName, m.Faces())
 
 			for _, f := range m.Faces() {
-				log.Debugf("index: processing face region %#v", f)
+				log.Debugf("index: processing face region %s", f)
 
 				// Calculate the face score, which is usually done by facenet.
 				f.Score = int(face.QualityThreshold(f.Area.Scale))
@@ -344,7 +344,7 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 				embeddings, err := ind.faceNet.Embeddings(FileName(file.FileRoot, file.FileName), f)
 
 				if err != nil {
-					log.Errorf("index: error when calculating embeddings for %s (%s)", logName, err.Error())
+					log.Errorf("index: %s (calculating embeddings for %s)", err, logName)
 					continue
 				}
 
@@ -361,13 +361,13 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 
 				// It is expected that adding the new face to the file will result in a new unsaved marker.
 				if !file.UnsavedMarkers() {
-					log.Errorf("index: face marker was not created for face %#v and file %s", f, logName)
+					log.Errorf("index: face marker was not created for face %s and file %s", f, logName)
 					continue
 				}
 
 				// Save the new marker.
 				if count, err := file.SaveMarkers(); err != nil {
-					log.Errorf("index: error when saving new marker or %s (%s)", logName, err.Error())
+					log.Errorf("index: %s (saving new marker for %s)", err, logName)
 					continue
 				} else if count == 0 {
 					log.Errorf("markers: did not save new marker for %s", logName)
@@ -379,10 +379,10 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 				changed, err := marker.SetName(f.Area.Name, entity.SrcMeta)
 
 				if err != nil {
-					log.Errorf("index: error when setting marker name for %s (%s)", marker.MarkerUID, err)
+					log.Errorf("index: %s (setting marker name for %s)", err, marker.MarkerUID)
 				} else if changed {
 					if err := marker.Save(); err != nil {
-						log.Errorf("index: error when saving marker %s (%s)", marker.MarkerUID, err)
+						log.Errorf("index: %s (saving marker %s)", err, marker.MarkerUID)
 					}
 				}
 			}

--- a/internal/photoprism/mediafile_faces.go
+++ b/internal/photoprism/mediafile_faces.go
@@ -24,13 +24,15 @@ const (
 	MWGUnitNormalized = "normalized"
 )
 
+// area describes a face region bounding box
 type area struct {
-	x float64
-	y float64
-	w float64
-	h float64
+	x float64 // face center
+	y float64 // face center
+	w float64 // face width
+	h float64 // face height
 }
 
+// Normalize takes the image orientation into account and rotates the area accordingly if needed.
 func (a *area) Normalize(orientation int) {
 	if orientation > 4 {
 		a.w, a.h = a.h, a.w
@@ -54,14 +56,17 @@ func (a *area) Normalize(orientation int) {
 	a.y = math.Abs(a.y - swapY)
 }
 
+// Row calculates the face region's centerpoint along the Y axis.
 func (a area) Row(metadata meta.Data) int {
 	return int(a.y * float64(metadata.ActualHeight()))
 }
 
+// Col calculates the face region's centerpoint along the X axis.
 func (a area) Col(metadata meta.Data) int {
 	return int(a.x * float64(metadata.ActualWidth()))
 }
 
+// Scale calculates the size of the face region (which is square).
 func (a area) Scale(metadata meta.Data) int {
 	// Determine how to clip the region rectangle - along the short ot long side
 	fittingFn := math.Min // or math.Max

--- a/internal/photoprism/mediafile_faces.go
+++ b/internal/photoprism/mediafile_faces.go
@@ -1,0 +1,102 @@
+package photoprism
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/photoprism/photoprism/internal/face"
+)
+
+// HasFaces returns whether the media contains face region metadata.
+func (m *MediaFile) HasFaces() bool {
+	if len(m.MetaData().Regions) > 0 {
+		// Metadata Working Group (MWG) Format
+		return true
+	} else if len(m.MetaData().RegionsMP) > 0 {
+		// Microsoft Windows Live Photo Gallery (WLPG)
+		return true
+	}
+
+	return false
+}
+
+// Faces returns all face region metadata for the given media.
+func (m *MediaFile) Faces() face.Faces {
+	faces := face.Faces{}
+
+	fittingFn := math.Min // or math.Max
+
+	if len(m.MetaData().Regions) > 0 {
+		for _, region := range m.MetaData().Regions {
+			if !strings.EqualFold(region.Type, "face") {
+				continue
+			}
+
+			face := face.Face{
+				Rows: m.Height(),
+				Cols: m.Width(),
+				Area: face.Area{
+					Name:  region.Name,
+					Row:   int(region.Area.Y * float32(m.Height())),
+					Col:   int(region.Area.X * float32(m.Width())),
+					Scale: int(fittingFn(float64(region.Area.H)*float64(m.Height()), float64(region.Area.W)*float64(m.Width()))),
+				},
+			}
+
+			faces = append(faces, face)
+		}
+	}
+
+	if len(m.MetaData().RegionsMP) > 0 {
+		for _, region := range m.MetaData().RegionsMP {
+			rect := strings.Split(strings.ReplaceAll(region.Rectangle, " ", ""), ",")
+			if len(rect) != 4 {
+				log.Warnf("faces: face region rectangle '%v' does not contain 4 values (%s)", rect, m.FileName())
+				continue
+			}
+
+			x, err := strconv.ParseFloat(rect[0], 64)
+			if err != nil {
+				log.Warnf("faces: face region x %s is not a float (%s)", rect[0], m.FileName())
+				continue
+			}
+
+			y, err := strconv.ParseFloat(rect[1], 64)
+			if err != nil {
+				log.Warnf("faces: face region y %s is not a float (%s)", rect[1], m.FileName())
+				continue
+			}
+
+			w, err := strconv.ParseFloat(rect[2], 64)
+			if err != nil {
+				log.Warnf("faces: face region w %s is not a float (%s)", rect[2], m.FileName())
+				continue
+			}
+
+			h, err := strconv.ParseFloat(rect[3], 64)
+			if err != nil {
+				log.Warnf("faces: face region h %s is not a float (%s)", rect[3], m.FileName())
+				continue
+			}
+
+			x += w / 2
+			y += h / 2
+
+			face := face.Face{
+				Rows: m.Height(),
+				Cols: m.Width(),
+				Area: face.Area{
+					Name:  region.PersonDisplayName,
+					Row:   int(y * float64(m.Height())),
+					Col:   int(x * float64(m.Width())),
+					Scale: int(fittingFn(h*float64(m.Height()), w*float64(m.Width()))),
+				},
+			}
+
+			faces = append(faces, face)
+		}
+	}
+
+	return faces
+}

--- a/internal/photoprism/mediafile_faces.go
+++ b/internal/photoprism/mediafile_faces.go
@@ -31,13 +31,13 @@ func (m *MediaFile) HasFaces() bool {
 	return false
 }
 
-// Faces returns all face region metadata for the given media.
+// Faces returns all unique metadata-based face regions for the given media.
 func (m *MediaFile) Faces() face.Faces {
 	faces := face.Faces{}
 
-	faces = append(faces, m.facesIPTC()...)
-	faces = append(faces, m.facesMWG()...)
-	faces = append(faces, m.facesWLPG()...)
+	faces.AppendIfNotContains(m.facesIPTC()...)
+	faces.AppendIfNotContains(m.facesMWG()...)
+	faces.AppendIfNotContains(m.facesWLPG()...)
 
 	return faces
 }


### PR DESCRIPTION
Read the most popular face region formats from exif/xmp and import them into PhotoPrism. The following formats are supported: IPTC, MWG, WLPG

During indexing, the file metadata information will be read and if it contains exif face regions, they will be imported into photoprism. No face clustering or auto-tagging will be performed, rather the information from the exif metadata will be imported as-is.

During indexing, face regions will be de-duplicated (in case the same face is described in multiple formats).
Both "normal" as well as rotated images are supported (all 8 different orientations).
In case a face region is ignored during import, the reason will be included in the logs (e.g. malformed data or unsupported input).

The following scenarios are supported and have been tested:

- [x] index the library from scratch using this pr: all exif face regions are successfully imported
- [x] reindex the library (after 1.): all exif face regions are skipped, as they have been imported during index
- [x] reset face data (after 1.) and reindex the library: all exif face regions are successfully imported
- [x] index the library from scratch using current preview branch and then reindex the library using this pr: all exif face regions are successfully imported
- [x] index the library from scratch using current preview branch, manually name some of the detected faces which also have exif face regions and then reindex the library using this pr: the manually named markers will be kept as-is (even if the manual name does not match the exif name) and the rest of the exif face regions will be imported; this might result in multiple subjects for the same person (if the names does not match), but that's being detected by photoprism `faces: marker [m] face [F] has ambiguous subjects [j1] <> [j2], subject source meta`

Sources:
- https://github.com/exiftool/exiftool/blob/master/config_files/convert_regions.config
- https://github.com/bpatrik/pigallery2/blob/dc7bc032cec8156bb77416896bc271497e89bc8d/src/backend/model/threading/MetadataLoader.ts#L318-L352
- https://github.com/bpatrik/ts-exif-parser/blob/bd6bb335b1923ff55be5dd42db434bde455c5204/lib/ExifData.ts#L3-L12
- https://www.iptc.org/std/photometadata/documentation/userguide/
- https://s3.amazonaws.com/software.tagthatphoto.com/docs/mwg_guidance.pdf
- https://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/

related to https://github.com/photoprism/photoprism/issues/747, https://github.com/photoprism/photoprism/issues/554, https://github.com/photoprism/photoprism/issues/1570