### PR TITLE
Show the correct photo count for smart albums

### DIFF
--- a/internal/search/albums.go
+++ b/internal/search/albums.go
@@ -171,7 +171,11 @@ func Albums(f form.SearchAlbums) (results AlbumResults, err error) {
 		if album.AlbumType == entity.AlbumDefault && album.AlbumFilter != "" {
 			f := form.SearchPhotos{Filter: album.AlbumFilter}
 
-			_, count, err := Photos(f)
+			if err := f.ParseQueryString(); err != nil {
+				return results, err
+			}
+
+			_, count, err := PhotoIds(f)
 			if err != nil {
 				return results, err
 			}


### PR DESCRIPTION
Due to upstream changes in the photo search module, the incorrect photo count was shown for smart albums.

related to photoprism#1431, #58 