### PR TITLE
Set cover image for people

### DIFF
--- a/frontend/src/component/photo/clipboard.vue
+++ b/frontend/src/component/photo/clipboard.vue
@@ -184,6 +184,7 @@ import Notify from "common/notify";
 import Event from "pubsub-js";
 import download from "common/download";
 import Photo from "model/photo";
+import Subject from "model/subject";
 
 export default {
   name: 'PPhotoClipboard',
@@ -412,7 +413,14 @@ export default {
     },
     setCover() {
       new Photo().find(this.selection[0]).then(p => {
-        Api.put(this.album.getEntityResource(), {Thumb: p.mainFileHash(), ThumbSrc: src.Manual}).then(() => this.onSetCover());
+        let thumb = p.mainFileHash();
+
+        // For subjects we need to find the subject marker within the main file.
+        if (this.album.collectionResource() === Subject.getCollectionResource()) {
+          thumb = p.mainFile().Markers.find(m => m.SubjUID === this.album.getId()).Thumb;
+        }
+
+        Api.put(this.album.getEntityResource(), {Thumb: thumb, ThumbSrc: src.Manual}).then(() => this.onSetCover());
       });
     },
     onSetCover() {

--- a/frontend/src/component/photo/clipboard.vue
+++ b/frontend/src/component/photo/clipboard.vue
@@ -34,7 +34,6 @@
           <v-icon>cloud</v-icon>
         </v-btn>
 
-        
         <v-btn
             v-if="context !== 'archive' && context !== 'review' && navigatorCanShare" fab dark
             small
@@ -179,6 +178,7 @@
 </template>
 <script>
 import Api from "common/api";
+import * as src from "common/src";
 import Util from "common/util";
 import Notify from "common/notify";
 import Event from "pubsub-js";
@@ -302,7 +302,7 @@ export default {
       if (this.busy) {
         return;
       }
-      
+
       this.busy = true;
       this.dialog.album = false;
 
@@ -348,7 +348,7 @@ export default {
       this.busy = true;
 
       switch (this.selection.length) {
-        case 0: 
+        case 0:
           this.busy = false;
           return;
         case 1:
@@ -358,7 +358,7 @@ export default {
               this.busy = false;
             });
           break;
-        default: 
+        default:
           Api.post("zip", {"photos": this.selection})
             .then(r => {
               this.onDownload(`${this.$config.apiUri}/zip/${r.data.filename}?t=${this.$config.downloadToken()}`);
@@ -412,7 +412,7 @@ export default {
     },
     setCover() {
       new Photo().find(this.selection[0]).then(p => {
-        Api.put(this.album.getEntityResource(), {Thumb: p.mainFileHash(), ThumbSrc: "cover"}).then(() => this.onSetCover());
+        Api.put(this.album.getEntityResource(), {Thumb: p.mainFileHash(), ThumbSrc: src.Manual}).then(() => this.onSetCover());
       });
     },
     onSetCover() {

--- a/frontend/src/model/rest.js
+++ b/frontend/src/model/rest.js
@@ -144,6 +144,10 @@ export class Rest extends Model {
     });
   }
 
+  collectionResource() {
+    return this.constructor.getCollectionResource();
+  }
+
   modelName() {
     return this.constructor.getModelName();
   }

--- a/frontend/src/model/subject.js
+++ b/frontend/src/model/subject.js
@@ -61,10 +61,10 @@ export class Subject extends RestModel {
 
   route(view) {
     if (this.Slug && (!this.Type || this.Type === SubjPerson)) {
-      return { name: view, query: { q: `person:${this.Slug}` } };
+      return { name: view, query: { person: this.Slug } };
     }
 
-    return { name: view, query: { q: "subject:" + this.UID } };
+    return { name: view, query: { subject: this.UID } };
   }
 
   classes(selected) {

--- a/frontend/tests/unit/model/label_test.js
+++ b/frontend/tests/unit/model/label_test.js
@@ -10,7 +10,7 @@ describe("model/label", () => {
     const label = new Label(values);
     const result = label.route("test");
     assert.equal(result.name, "test");
-    assert.equal(result.query.q, undefined);
+    assert.isUndefined(result.query.q);
     assert.equal(result.query.label, "black-cat");
   });
 

--- a/frontend/tests/unit/model/subject_test.js
+++ b/frontend/tests/unit/model/subject_test.js
@@ -18,7 +18,8 @@ describe("model/subject", () => {
     const subject = new Subject(values);
     const result = subject.route("test");
     assert.equal(result.name, "test");
-    assert.equal(result.query.q, "subject:s123ghytrfggd");
+    assert.isUndefined(result.query.q);
+    assert.equal(result.query.subject, "s123ghytrfggd");
     const values2 = {
       UID: "s123ghytrfggd",
       Type: "person",
@@ -29,7 +30,8 @@ describe("model/subject", () => {
     const subject2 = new Subject(values2);
     const result2 = subject2.route("test");
     assert.equal(result2.name, "test");
-    assert.equal(result2.query.q, "person:jane-doe");
+    assert.isUndefined(result2.query.q);
+    assert.equal(result2.query.person, "jane-doe");
   });
 
   it("should return classes", () => {
@@ -246,5 +248,9 @@ describe("model/subject", () => {
   it("should get model name", () => {
     const result = Subject.getModelName();
     assert.equal(result, "Subject");
+  });
+
+  it("should have a consistent collection resource", () => {
+    assert.equal(Subject.getCollectionResource(), new Subject({}).collectionResource());
   });
 });

--- a/internal/entity/subject.go
+++ b/internal/entity/subject.go
@@ -327,6 +327,14 @@ func (m *Subject) SaveForm(f form.Subject) (changed bool, err error) {
 		changed = true
 	}
 
+	// Change thumbnail?
+	if m.Thumb != f.SubjThumb {
+		m.Thumb = f.SubjThumb
+		m.ThumbSrc = f.SubjThumbSrc
+
+		changed = true
+	}
+
 	// Change visibility?
 	if m.SubjHidden != f.SubjHidden || m.SubjPrivate != f.SubjPrivate || m.SubjExcluded != f.SubjExcluded {
 		m.SubjHidden = f.SubjHidden
@@ -356,6 +364,8 @@ func (m *Subject) SaveForm(f form.Subject) (changed bool, err error) {
 			"SubjHidden":   m.SubjHidden,
 			"SubjPrivate":  m.SubjPrivate,
 			"SubjExcluded": m.SubjExcluded,
+			"Thumb": m.Thumb,
+			"ThumbSrc": m.ThumbSrc,
 		}
 
 		if err := m.Updates(values); err == nil {

--- a/internal/entity/subject_test.go
+++ b/internal/entity/subject_test.go
@@ -293,6 +293,35 @@ func TestSubject_SaveForm(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+	t.Run("change thumbnail", func(t *testing.T) {
+		subj := NewSubject("Me", SubjPerson, SrcManual)
+
+		if err := subj.Create(); err != nil {
+			t.Fatal(err)
+		}
+
+		subjForm, err := form.NewSubject(subj)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		subjForm.SubjThumb = "thumb-000"
+		subjForm.SubjThumbSrc = "manual"
+
+		if changed, err := subj.SaveForm(subjForm); err != nil {
+			t.Fatal(err)
+		} else if !changed {
+			t.Fatal("subject must be changed")
+		}
+
+		assert.Equal(t, "thumb-000", subj.Thumb)
+		assert.Equal(t, "manual", subj.ThumbSrc)
+
+		if err := subj.Delete(); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestSubject_UpdateName(t *testing.T) {

--- a/internal/form/subject.go
+++ b/internal/form/subject.go
@@ -12,6 +12,8 @@ type Subject struct {
 	SubjHidden   bool   `json:"Hidden"`
 	SubjPrivate  bool   `json:"Private"`
 	SubjExcluded bool   `json:"Excluded"`
+	SubjThumb    string `json:"Thumb"`
+	SubjThumbSrc string `json:"ThumbSrc"`
 }
 
 func NewSubject(m interface{}) (f Subject, err error) {

--- a/internal/form/subject_test.go
+++ b/internal/form/subject_test.go
@@ -17,12 +17,16 @@ func TestNewSubject(t *testing.T) {
 			SubjHidden   bool   `json:"Hidden"`
 			SubjPrivate  bool   `json:"Private"`
 			SubjExcluded bool   `json:"Excluded"`
+			SubjThumb string   `json:"Thumb"`
+			SubjThumbSrc string   `json:"ThumbSrc"`
 		}{
 			SubjName:     "Foo",
 			SubjAlias:    "bar",
 			SubjFavorite: true,
 			SubjHidden:   true,
 			SubjExcluded: false,
+			SubjThumb: "thumb-000",
+			SubjThumbSrc: "manual",
 		}
 
 		f, err := NewSubject(m)
@@ -36,5 +40,7 @@ func TestNewSubject(t *testing.T) {
 		assert.Equal(t, true, f.SubjFavorite)
 		assert.Equal(t, true, f.SubjHidden)
 		assert.Equal(t, false, f.SubjExcluded)
+		assert.Equal(t, "thumb-000", f.SubjThumb)
+		assert.Equal(t, "manual", f.SubjThumbSrc)
 	})
 }


### PR DESCRIPTION
Extend the clipboard to allow setting a cover image for a person similarly to how it is done for all album types and labels. This only works for "people" (meaning subjects that have been assigned a name), it does not work for "faces" (subjects that have not been named and which appear under "New").

related to https://github.com/photoprism/photoprism/discussions/2480, https://github.com/photoprism/photoprism/issues/383, https://github.com/kvalev/photoprism/pull/2