### PR TITLE
Support for Top Shot motion photos

### DIFF
--- a/internal/ffmpeg/convert.go
+++ b/internal/ffmpeg/convert.go
@@ -27,6 +27,7 @@ func AvcConvertCommand(fileName, avcName, ffmpegBin, bitrate string, encoder Avc
 			"-pix_fmt", "yuv420p",
 			"-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
 			"-f", "mp4",
+			"-map", "0:v",
 			"-y",
 			avcName,
 		)
@@ -55,6 +56,7 @@ func AvcConvertCommand(fileName, avcName, ffmpegBin, bitrate string, encoder Avc
 			"-b:v", bitrate,
 			"-bitrate", bitrate,
 			"-f", "mp4",
+			"-map", "0:v",
 			"-y",
 			avcName,
 		)
@@ -74,6 +76,7 @@ func AvcConvertCommand(fileName, avcName, ffmpegBin, bitrate string, encoder Avc
 			"-r", "30",
 			"-b:v", bitrate,
 			"-f", "mp4",
+			"-map", "0:v",
 			"-y",
 			avcName,
 		)
@@ -99,6 +102,7 @@ func AvcConvertCommand(fileName, avcName, ffmpegBin, bitrate string, encoder Avc
 			"-level:v", "41",
 			"-coder:v", "1",
 			"-f", "mp4",
+			"-map", "0:v",
 			"-y",
 			avcName,
 		)
@@ -120,6 +124,7 @@ func AvcConvertCommand(fileName, avcName, ffmpegBin, bitrate string, encoder Avc
 			"-r", "30",
 			"-b:v", bitrate,
 			"-f", "mp4",
+			"-map", "0:v",
 			"-y",
 			avcName,
 		)
@@ -138,6 +143,7 @@ func AvcConvertCommand(fileName, avcName, ffmpegBin, bitrate string, encoder Avc
 			"-r", "30",
 			"-b:v", bitrate,
 			"-f", "mp4",
+			"-map", "0:v",
 			"-y",
 			avcName,
 		)

--- a/internal/photoprism/convert_jpeg.go
+++ b/internal/photoprism/convert_jpeg.go
@@ -180,7 +180,7 @@ func (c *Convert) JpegConvertCommand(f *MediaFile, jpegName string, xmpName stri
 			return nil, useMutex, fmt.Errorf("no suitable converter found")
 		}
 	} else if f.IsVideo() && c.conf.FFmpegEnabled() {
-		result = exec.Command(c.conf.FFmpegBin(), "-y", "-i", f.FileName(), "-ss", "00:00:00.001", "-vframes", "1", jpegName)
+		result = exec.Command(c.conf.FFmpegBin(), "-y", "-i", f.FileName(), "-ss", "00:00:00.001", "-vframes", "1", "-map", "0:v", jpegName)
 	} else if f.IsHEIF() && c.conf.HeifConvertEnabled() {
 		result = exec.Command(c.conf.HeifConvertBin(), f.FileName(), jpegName)
 	} else {


### PR DESCRIPTION
This fixes a problem with pictures shot with newer Google Camera, where the motion photos feature is now called as Top Shot.

### Investigation

The problem reflects in the PP logs as:

```
photoprism_1  | level=error msg="video: record not found"                                                                             
photoprism_1  | level=debug msg="server: GET /api/v1/videos/08db9b1963e3ba9761064c679f99acc215c6322d/96a75e96/avc (200) [2.224971ms]" 
photoprism_1  | level=error msg="video: record not found"                                                                             
photoprism_1  | level=debug msg="server: GET /api/v1/videos/e0dfeafdfacdded7ab6eb7b20a377caf8676ae35/96a75e96/avc (200) [2.303049ms]" 
```

On mouse hover over the motion photo, the extracted video could not be found. The actual problem occurs during indexing, when photoprism tries to generate a thumbnail for the video file (extracted from the motion photo). For one reason or another the thumbnail cannot be created, so photoprism considers the video file to be corrupted and does not create an entry in the `files` database. This in turn leads to the errors when hovering over the motion photo in the UI, as photoprism tries to load the "related" video file, but there is no database entry (although the file physically exists).

The problem boils down to how photoprism creates a thumbnail for a given video. When running the `ffmpeg` thumbnail creation command the process terminates successfully (exit code 0), but the following message can be found in the ffmpeg logs:

```
video:0kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
Output file is empty, nothing was encoded (check -ss / -t / -frames parameters if used)
```

Meaning `ffmpeg` could not create the thumbnail given the following command line parameters:

https://github.com/kvalev/photoprism/blob/bed936010d815cc5765f7afd4b5ae68d2be42629/internal/photoprism/convert_jpeg.go#L183

### Top Shot vs "normal" videos

Running `ffmpeg` for both Top Shot and previous version motion photos reveals that the Top Shot video embedded in the motion photo has more than one video stream.

Here is the output for an older video, which has one video stream (#0:0) and two metadata streams (#0:1 and #0:2).

```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'PXL_20210506_083558892.MP.mp4':
  Metadata:
    major_brand     : mp42
    minor_version   : 0
    compatible_brands: isommp42
    creation_time   : 2021-05-06T08:35:58.000000Z
  Duration: 00:00:01.53, start: 0.000000, bitrate: 11184 kb/s
  Stream #0:0[0x1](eng): Video: h264 (Baseline) (avc1 / 0x31637661), yuvj420p(pc, smpte170m/bt470bg/smpte170m, progressive), 1280x720, 11060 kb/s, SAR 1:1 DAR 16:9, 30.66 fps, 30 tbr, 90k tbn (default)
    Metadata:
      creation_time   : 2021-05-06T08:35:58.000000Z
      handler_name    : VideoHandle
      vendor_id       : [0][0][0][0]
  Stream #0:1[0x2](eng): Data: none (mett / 0x7474656D), 110 kb/s (default)
    Metadata:
      creation_time   : 2021-05-06T08:35:58.000000Z
      handler_name    : MetaHandle
  Stream #0:2[0x3](eng): Data: none (mett / 0x7474656D), 0 kb/s (default)
    Metadata:
      creation_time   : 2021-05-06T08:35:58.000000Z
      handler_name    : MetaHandle
Stream mapping:
  Stream #0:0 -> #0:0 (h264 (native) -> mjpeg (native))
```

Thus `ffmpeg` has no any other choice, but the use the only video stream for creating the thumbnail:

```
Output #0, image2, to 'PXL_20210506_083558892.MP.mp4.jpg':
  Metadata:
    major_brand     : mp42
    minor_version   : 0
    compatible_brands: isommp42
    encoder         : Lavf59.27.100
  Stream #0:0(eng): Video: mjpeg, yuvj420p(pc, smpte170m/bt470bg/smpte170m, progressive), 1280x720 [SAR 1:1 DAR 16:9], q=2-31, 200 kb/s, 30 fps, 30 tbn (default)
    Metadata:
      creation_time   : 2021-05-06T08:35:58.000000Z
      handler_name    : VideoHandle
      vendor_id       : [0][0][0][0]
      encoder         : Lavc59.37.100 mjpeg
    Side data:
      cpb: bitrate max/min/avg: 0/0/200000 buffer size: 0 vbv_delay: N/A
frame=    1 fps=0.0 q=7.9 Lsize=N/A time=00:00:00.03 bitrate=N/A speed=0.644x    
video:133kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
```

However when dealing with Top Shot videos `ffmpeg` outputs the following:

```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'PXL_20220908_142849973.MP.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 131072
    compatible_brands: isomiso2mp41
    creation_time   : 2022-09-08T08:58:50.000000Z
  Duration: 00:00:02.96, start: 0.000000, bitrate: 2266 kb/s
  Stream #0:0[0x1](eng): Video: h264 (High) (avc1 / 0x31637661), yuv420p(tv, bt470bg/bt470bg/smpte170m, progressive), 640x480, 1959 kb/s, SAR 1:1 DAR 4:3, 30.37 fps, 30 tbr, 90k tbn (default)
    Metadata:
      creation_time   : 2022-09-08T08:58:50.000000Z
      handler_name    : VideoHandle
      vendor_id       : [0][0][0][0]
    Side data:
      displaymatrix: rotation of -180.00 degrees
  Stream #0:1[0x2](eng): Video: h264 (High) (avc1 / 0x31637661), yuv420p(tv, bt470bg/bt470bg/smpte170m, progressive), 2048x1536, 965 kb/s, SAR 1:1 DAR 4:3, 1.77 fps, 1.77 tbr, 90k tbn (default)
    Metadata:
      creation_time   : 2022-09-08T08:58:50.000000Z
      handler_name    : VideoHandle
      vendor_id       : [0][0][0][0]
    Side data:
      displaymatrix: rotation of -180.00 degrees
  Stream #0:2[0x3](eng): Data: none (mett / 0x7474656D), 109 kb/s (default)
    Metadata:
      creation_time   : 2022-09-08T08:58:50.000000Z
      handler_name    : MetaHandle
  Stream #0:3[0x4](eng): Data: none (mett / 0x7474656D), 0 kb/s (default)
    Metadata:
      creation_time   : 2022-09-08T08:58:50.000000Z
      handler_name    : MetaHandle
Stream mapping:
  Stream #0:1 -> #0:0 (h264 (native) -> mjpeg (native))
```

Note that now, in addition to the two metadata streams (#0:2 and #0:3), there are two video streams - #0:0 and #0:1 and `ffmpeg` favors the second one (#0:1). This is due to the fact, [that in the absence of any map options for a particular output file, `ffmpeg` picks the stream with the highest resolution](https://ffmpeg.org/ffmpeg.html#Automatic-stream-selection) (for videos). And for some reason (TBD), `ffmpeg` cannot create a thumbnail for the selected high-resolution video stream:

```
Output #0, image2, to 'PXL_20220908_142849973.MP.mp4.jpg':
  Metadata:
    major_brand     : isom
    minor_version   : 131072
    compatible_brands: isomiso2mp41
    encoder         : Lavf59.27.100
  Stream #0:0(eng): Video: mjpeg, yuvj420p(pc), 2048x1536 [SAR 1:1 DAR 4:3], q=2-31, 200 kb/s, 1.77 fps, 1.77 tbn (default)
    Metadata:
      creation_time   : 2022-09-08T08:58:50.000000Z
      handler_name    : VideoHandle
      vendor_id       : [0][0][0][0]
      encoder         : Lavc59.37.100 mjpeg
    Side data:
      cpb: bitrate max/min/avg: 0/0/200000 buffer size: 0 vbv_delay: N/A
      displaymatrix: rotation of -0.00 degrees
frame=    0 fps=0.0 q=0.0 Lsize=N/A time=00:00:00.00 bitrate=N/A speed=   0x    
video:0kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
Output file is empty, nothing was encoded (check -ss / -t / -frames parameters if used)
```

### Solution

The solution is to override `ffmpeg`'s stream resolution using [the `-map` parameter](https://trac.ffmpeg.org/wiki/Map) and force it to take all video streams into account by adding the following additional command line arguments: `-map 0:v`

Doing results in `ffmpeg` taking both video streams into account and is thus able to create the thumbnail by using the lower resolution (but "working") stream (#0:0 in the log below):

```
Output #0, image2, to 'PXL_20220908_142849973.MP.mp4.jpg':
  Metadata:
    major_brand     : isom
    minor_version   : 131072
    compatible_brands: isomiso2mp41
    encoder         : Lavf59.27.100
  Stream #0:0(eng): Video: mjpeg, yuvj420p(pc, bt470bg/bt470bg/smpte170m, progressive), 640x480 [SAR 1:1 DAR 4:3], q=2-31, 200 kb/s, 30 fps, 30 tbn (default)
    Metadata:
      creation_time   : 2022-09-08T08:58:50.000000Z
      handler_name    : VideoHandle
      vendor_id       : [0][0][0][0]
      encoder         : Lavc59.37.100 mjpeg
    Side data:
      cpb: bitrate max/min/avg: 0/0/200000 buffer size: 0 vbv_delay: N/A
      displaymatrix: rotation of -0.00 degrees
  Stream #0:1(eng): Video: mjpeg, yuvj420p(pc), 2048x1536, q=2-31, 200 kb/s, 1.77 fps, 1.77 tbn (default)
    Metadata:
      creation_time   : 2022-09-08T08:58:50.000000Z
      handler_name    : VideoHandle
      vendor_id       : [0][0][0][0]
      encoder         : Lavc59.37.100 mjpeg
    Side data:
      cpb: bitrate max/min/avg: 0/0/200000 buffer size: 0 vbv_delay: N/A
      displaymatrix: rotation of -0.00 degrees
frame=    1 fps=0.0 q=4.4 Lq=0.0 size=N/A time=00:00:00.03 bitrate=N/A speed=0.375x    
video:20kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
```
