### PR TITLE
Properly store motion photo related files

### DIFF
--- a/internal/photoprism/convert_avc.go
+++ b/internal/photoprism/convert_avc.go
@@ -29,7 +29,12 @@ func (c *Convert) ToAvc(f *MediaFile, encoder ffmpeg.AvcEncoder, noMutex, force 
 		return nil, fmt.Errorf("convert: %s is empty", clean.Log(f.RootRelName()))
 	}
 
-	avcName := fs.VideoAVC.FindFirst(f.FileName(), []string{c.conf.SidecarPath(), fs.HiddenPath}, c.conf.OriginalsPath(), false)
+	baseDir := c.conf.OriginalsPath()
+	if f.InSidecar() {
+		baseDir = c.conf.SidecarPath()
+	}
+
+	avcName := fs.VideoAVC.FindFirst(f.FileName(), []string{c.conf.SidecarPath(), fs.HiddenPath}, baseDir, false)
 
 	mediaFile, err := NewMediaFile(avcName)
 
@@ -45,8 +50,8 @@ func (c *Convert) ToAvc(f *MediaFile, encoder ffmpeg.AvcEncoder, noMutex, force 
 		return nil, fmt.Errorf("convert: ffmpeg is disabled for transcoding %s", f.RootRelName())
 	}
 
-	fileName := f.RelName(c.conf.OriginalsPath())
-	avcName = fs.FileName(f.FileName(), c.conf.SidecarPath(), c.conf.OriginalsPath(), fs.ExtAVC)
+	fileName := f.RelName(baseDir)
+	avcName = fs.FileName(f.FileName(), c.conf.SidecarPath(), baseDir, fs.ExtAVC)
 
 	cmd, useMutex, err := c.AvcConvertCommand(f, avcName, encoder)
 

--- a/internal/photoprism/convert_avc_test.go
+++ b/internal/photoprism/convert_avc_test.go
@@ -64,6 +64,45 @@ func TestConvert_ToAvc(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, avcFile)
 	})
+
+	t.Run("jpg in sidecar folder", func(t *testing.T) {
+		conf := config.TestConfig()
+		convert := NewConvert(conf)
+
+		sourceFile := filepath.Join(conf.ExamplesPath(), "gopher-video.mp4")
+		inputFile := filepath.Join(conf.SidecarPath(), conf.ExamplesPath(), "gopher-video.mp4")
+		outputName := filepath.Join(conf.SidecarPath(), conf.ExamplesPath(), "gopher-video.mp4.avc")
+
+		_ = os.Remove(outputName)
+
+		err := fs.Copy(sourceFile, inputFile)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Truef(t, fs.FileExists(inputFile), "input file does not exist: %s", inputFile)
+
+		mf, err := NewMediaFile(inputFile)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		avcFile, err := convert.ToAvc(mf, "", false, false)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, avcFile.FileName(), outputName)
+		assert.Truef(t, fs.FileExists(avcFile.FileName()), "output file does not exist: %s", avcFile.FileName())
+
+		t.Logf("video metadata: %+v", avcFile.MetaData())
+
+		_ = os.Remove(inputFile)
+		_ = os.Remove(outputName)
+	})
 }
 
 func TestConvert_AvcBitrate(t *testing.T) {

--- a/internal/photoprism/convert_jpeg.go
+++ b/internal/photoprism/convert_jpeg.go
@@ -32,7 +32,12 @@ func (c *Convert) ToJpeg(f *MediaFile, force bool) (*MediaFile, error) {
 		return f, nil
 	}
 
-	jpegName := fs.ImageJPEG.FindFirst(f.FileName(), []string{c.conf.SidecarPath(), fs.HiddenPath}, c.conf.OriginalsPath(), false)
+	baseDir := c.conf.OriginalsPath()
+	if f.InSidecar() {
+		baseDir = c.conf.SidecarPath()
+	}
+
+	jpegName := fs.ImageJPEG.FindFirst(f.FileName(), []string{c.conf.SidecarPath(), fs.HiddenPath}, baseDir, false)
 
 	mediaFile, err := NewMediaFile(jpegName)
 
@@ -48,7 +53,7 @@ func (c *Convert) ToJpeg(f *MediaFile, force bool) (*MediaFile, error) {
 			return mediaFile, nil
 		}
 	} else {
-		jpegName = fs.FileName(f.FileName(), c.conf.SidecarPath(), c.conf.OriginalsPath(), fs.ExtJPEG)
+		jpegName = fs.FileName(f.FileName(), c.conf.SidecarPath(), baseDir, fs.ExtJPEG)
 	}
 
 	if !c.conf.SidecarWritable() {

--- a/internal/photoprism/convert_jpeg_test.go
+++ b/internal/photoprism/convert_jpeg_test.go
@@ -47,6 +47,42 @@ func TestConvert_ToJpeg(t *testing.T) {
 		_ = os.Remove(outputName)
 	})
 
+	t.Run("Video in Sidecar Folder", func(t *testing.T) {
+		sourceFile := filepath.Join(conf.ExamplesPath(), "gopher-video.mp4")
+		inputFile := filepath.Join(conf.SidecarPath(), conf.ExamplesPath(), "gopher-video.mp4")
+		outputName := filepath.Join(conf.SidecarPath(), conf.ExamplesPath(), "gopher-video.mp4.jpg")
+
+		_ = os.Remove(outputName)
+
+		err := fs.Copy(sourceFile, inputFile)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Truef(t, fs.FileExists(inputFile), "input file does not exist: %s", inputFile)
+
+		mf, err := NewMediaFile(inputFile)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		jpegFile, err := convert.ToJpeg(mf, false)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, jpegFile.FileName(), outputName)
+		assert.Truef(t, fs.FileExists(jpegFile.FileName()), "output file does not exist: %s", jpegFile.FileName())
+
+		t.Logf("video metadata: %+v", jpegFile.MetaData())
+
+		_ = os.Remove(inputFile)
+		_ = os.Remove(outputName)
+	})
+
 	t.Run("Raw", func(t *testing.T) {
 		jpegFilename := filepath.Join(conf.ImportPath(), "fern_green.jpg")
 


### PR DESCRIPTION
Due to a bug, few motion photo related files were not stored in the proper sidecar folder. This affected the generated JPEG file from the extracted motion photo video and the transcoded AVC video file. (The files were still usable by PhotoPrism, just the location where they were stored was not optimal.)

Assuming a default PhotoPrism configuration, where the sidecar folder is named `/photoprism/storage/sidecar`, the aforementioned files were not stored next to the other sidecar files in `/photoprism/storage/sidecar/[FOLDER]`, instead they were erroneously put in `/photoprism/storage/sidecar/photoprism/storage/sidecar/[FOLDER]`.

With this PR, PhotoPrism will now store all motion photo related files to the correct sidecar folder. This will have the following implications:

1. When hovering over motion photos, PhotoPrism will now search the correct sidecar folder for the transcoded AVC file, meaning the previously generated AVC files will not be used anymore. Instead they will be recreated in the correct folder, which means a slight delay on the first hover. You can safely delete all AVC files from the incorrect, "nested" sidecar folder.
2. If you prefer you can delete the whole "nested" folder instead, but please note that the generated JPEGs stored in the folder are referenced in the PhotoPrism database. If you delete the whole folder you should run a complete rescan/reindex (only for the affected folders containing motion photos), so that the JPEGs are recreated in the correct sidecar folder and the database entries are updated.

related to #19 
