### PR TITLE
Search photos without geo information

### DIFF
--- a/internal/form/search_photos.go
+++ b/internal/form/search_photos.go
@@ -48,6 +48,7 @@ type SearchPhotos struct {
 	Diff      uint32    `form:"diff" notes:"Differential Perceptual Hash (000000-FFFFFF)"`
 	Mono      bool      `form:"mono" notes:"Finds pictures with few or no colors"`
 	Geo       bool      `form:"geo" notes:"Finds pictures with GPS location"`
+	NoGeo     bool      `form:"nogeo" notes:"Finds pictures without GPS location"`
 	Keywords  string    `form:"keywords"  example:"keywords:\"buffalo&water\"" notes:"Keywords, can be combined with & and |"`                                                                                        // Filter by keyword(s)
 	Label     string    `form:"label" example:"label:cat|dog" notes:"Label Name, OR search with |"`                                                                                                                   // Label name
 	Category  string    `form:"category"  notes:"Location Category Name"`                                                                                                                                             // Moments

--- a/internal/search/photos.go
+++ b/internal/search/photos.go
@@ -224,11 +224,9 @@ func searchPhotos(f form.SearchPhotos, resultCols string) (results PhotoResults,
 	// Filter by location?
 	if f.Geo == true {
 		s = s.Where("photos.cell_id <> 'zz'")
+	}
 
-		for _, where := range LikeAnyKeyword("k.keyword", f.Query) {
-			s = s.Where("files.photo_id IN (SELECT pk.photo_id FROM keywords k JOIN photos_keywords pk ON k.id = pk.keyword_id WHERE (?))", gorm.Expr(where))
-		}
-	} else if f.Query != "" {
+	if f.Query != "" {
 		if err := Db().Where(AnySlug("custom_slug", f.Query, " ")).Find(&labels).Error; len(labels) == 0 || err != nil {
 			log.Debugf("search: label %s not found, using fuzzy search", txt.LogParamLower(f.Query))
 

--- a/internal/search/photos.go
+++ b/internal/search/photos.go
@@ -224,6 +224,8 @@ func searchPhotos(f form.SearchPhotos, resultCols string) (results PhotoResults,
 	// Filter by location?
 	if f.Geo == true {
 		s = s.Where("photos.cell_id <> 'zz'")
+	} else if f.NoGeo {
+		s = s.Where("photos.cell_id = 'zz'")
 	}
 
 	if f.Query != "" {


### PR DESCRIPTION
Using the search filter `nogeo:true` you can now query for photos that do not have geo information. Alternatively you can use the `country:zz` filter, but that fails in case the country was estimated based on keywords (such as the folder name).