### PR TITLE
Update the photo title when adding a new face

### DIFF
--- a/internal/api/photo_face.go
+++ b/internal/api/photo_face.go
@@ -159,7 +159,15 @@ func CreatePhotoFace(router *gin.RouterGroup) {
 			}
 		}
 
-		PublishPhotoEvent(EntityUpdated, c.Param("uid"), c)
+		// Update photo metadata.
+		if p, err := query.PhotoByUID(file.PhotoUID); err != nil {
+			log.Errorf("markers: %s (find photo))", err)
+		} else if err := p.UpdateAndSaveTitle(); err != nil {
+			log.Errorf("markers: %s (update photo title)", err)
+		} else {
+			// Notify clients.
+			PublishPhotoEvent(EntityUpdated, file.PhotoUID, c)
+		}
 
 		event.Success("added photo face")
 


### PR DESCRIPTION
Until now when adding a new face (either manually or confirming one of the low-probability detections) the user needs to wait until the next index operation for the title to be updated, which is very inconvenient. Now the title will be updated simultaneously with adding the new face.

related to #51 