### PR TITLE
Generate share preview image for albums

### DIFF
--- a/internal/api/share_preview.go
+++ b/internal/api/share_preview.go
@@ -40,6 +40,14 @@ func SharePreview(router *gin.RouterGroup) {
 			return
 		}
 
+		album, err := entity.CachedAlbumByUID(share)
+
+		if err != nil {
+			log.Error(err)
+			c.Redirect(http.StatusTemporaryRedirect, conf.SitePreview())
+			return
+		}
+
 		thumbPath := path.Join(conf.ThumbCachePath(), "share")
 
 		if err := os.MkdirAll(thumbPath, os.ModePerm); err != nil {
@@ -66,7 +74,8 @@ func SharePreview(router *gin.RouterGroup) {
 		var f form.SearchPhotos
 
 		// Covers may only contain public content in shared albums.
-		f.Album = share
+		f.Album = album.AlbumUID
+		f.Filter = album.AlbumFilter
 		f.Public = true
 		f.Private = false
 		f.Hidden = false

--- a/internal/api/share_preview.go
+++ b/internal/api/share_preview.go
@@ -16,6 +16,7 @@ import (
 	"github.com/photoprism/photoprism/internal/entity"
 	"github.com/photoprism/photoprism/internal/form"
 	"github.com/photoprism/photoprism/internal/photoprism"
+	"github.com/photoprism/photoprism/internal/query"
 	"github.com/photoprism/photoprism/internal/search"
 	"github.com/photoprism/photoprism/internal/service"
 	"github.com/photoprism/photoprism/internal/thumb"
@@ -71,6 +72,42 @@ func SharePreview(router *gin.RouterGroup) {
 			return
 		}
 
+		if album.HasThumb() {
+			f, err := query.FileByHash(album.Thumb)
+
+			if err != nil {
+				log.Errorf("share: %s (retrieve thumbnail file for album %s)", err, &album)
+				c.Redirect(http.StatusTemporaryRedirect, conf.SitePreview())
+				return
+			}
+
+			p := f.RelatedPhoto()
+
+			if !p.PhotoPrivate && p.DeletedAt == nil {
+				size, _ := thumb.Sizes[thumb.Fit720]
+
+				fileName := photoprism.FileName(f.FileRoot, f.FileName)
+
+				if !fs.FileExists(fileName) {
+					log.Errorf("share: file %s is missing (thumbnail preview)", clean.Log(f.FileName))
+					c.Redirect(http.StatusTemporaryRedirect, conf.SitePreview())
+					return
+				}
+
+				thumbnail, err := thumb.FromFile(fileName, f.FileHash, conf.ThumbCachePath(), size.Width, size.Height, f.FileOrientation, size.Options...)
+
+				if err != nil {
+					log.Error(err)
+					c.Redirect(http.StatusTemporaryRedirect, conf.SitePreview())
+					return
+				}
+
+				c.File(thumbnail)
+
+				return
+			}
+		}
+
 		var f form.SearchPhotos
 
 		// Covers may only contain public content in shared albums.
@@ -111,7 +148,7 @@ func SharePreview(router *gin.RouterGroup) {
 			fileName := photoprism.FileName(f.FileRoot, f.FileName)
 
 			if !fs.FileExists(fileName) {
-				log.Errorf("share: file %s is missing (preview)", clean.Log(f.FileName))
+				log.Errorf("share: file %s is missing (single file preview)", clean.Log(f.FileName))
 				c.Redirect(http.StatusTemporaryRedirect, conf.SitePreview())
 				return
 			}
@@ -141,7 +178,7 @@ func SharePreview(router *gin.RouterGroup) {
 			fileName := photoprism.FileName(f.FileRoot, f.FileName)
 
 			if !fs.FileExists(fileName) {
-				log.Errorf("share: file %s is missing (preview)", clean.Log(f.FileName))
+				log.Errorf("share: file %s is missing (collage preview)", clean.Log(f.FileName))
 				c.Redirect(http.StatusTemporaryRedirect, conf.SitePreview())
 				return
 			}


### PR DESCRIPTION
Smart albums (such as folders, moments, states) now have a share preview image, which was previously missing.

If the shared album (smart or otherwise) has a manually configured cover image it will be used as share preview image. Additional checks are done to ensure that the thumbnail image is not private, hidden or archived.

Previously:
<img width="458" alt="Screenshot 2022-09-29 at 00 12 51" src="https://user-images.githubusercontent.com/270592/192902249-8cc48288-43aa-4199-a764-d9a35ce4f95a.png">

Now
<img width="456" alt="Screenshot 2022-09-29 at 00 08 32" src="https://user-images.githubusercontent.com/270592/192902233-7025a36a-9ddd-4740-a016-e3e38ff16ec3.png">

(Used https://www.opengraph.xyz/ & `ngrok http 2342` to visualize the OpenGraph meta tags.)

related to https://github.com/photoprism/photoprism/issues/1305