### PR TITLE
Update people count when manually adding a new face

### DIFF
--- a/frontend/src/model/photo.js
+++ b/frontend/src/model/photo.js
@@ -985,9 +985,12 @@ export class Photo extends RestModel {
   }
 
   addFace(face) {
-    return Api.post(this.getEntityResource() + "/faces", face).then((response) =>
-      Promise.resolve(response.data)
-    );
+    return Api.post(this.getEntityResource() + "/faces", face)
+      .then((response) => {
+        this.Faces = (this.Faces || 0) + 1;
+        return response;
+      })
+      .then((response) => Promise.resolve(response.data));
   }
 
   update() {


### PR DESCRIPTION
Update the people badge on the photo details page when a new face has been added (either by confirming a low-probability match or by manually selecting it).

related to #51
