### PR TITLE
Grant partner accounts limited access

### DIFF
--- a/internal/acl/permissions.go
+++ b/internal/acl/permissions.go
@@ -16,10 +16,12 @@ var Permissions = ACL{
 	},
 	ResourceAlbums: Roles{
 		RoleAdmin: Actions{ActionDefault: true},
+		RolePartner: Actions{ActionSearch: true, ActionRead: true},
 		RoleGuest: Actions{ActionSearch: true, ActionRead: true},
 	},
 	ResourcePhotos: Roles{
 		RoleAdmin: Actions{ActionDefault: true},
+		RolePartner: Actions{ActionSearch: true, ActionRead: true, ActionLike: true},
 		RoleGuest: Actions{ActionSearch: true, ActionRead: true, ActionDownload: true},
 	},
 	ResourceUsers: Roles{

--- a/internal/api/photo_face.go
+++ b/internal/api/photo_face.go
@@ -23,7 +23,7 @@ import (
 //   uid: string PhotoUID as returned by the API
 func GetPhotoFaces(router *gin.RouterGroup) {
 	router.GET("/photos/:uid/faces", func(c *gin.Context) {
-		s := Auth(SessionID(c), acl.ResourcePhotos, acl.ActionUpdate)
+		s := Auth(SessionID(c), acl.ResourcePhotos, acl.ActionRead)
 
 		if s.Invalid() {
 			AbortUnauthorized(c)


### PR DESCRIPTION
As a stop-gap until proper multiuser support is implemented, grant user accounts with the "Partner" role limited access to the system. The following actions are granted:

- search and view all types of albums (folders, moments, "smart albums", etc)
- search and view and photos
- like/favorite photos