### PR TITLE
Search photos by description

### DIFF
--- a/internal/entity/photo_fixtures.go
+++ b/internal/entity/photo_fixtures.go
@@ -1663,7 +1663,7 @@ var PhotoFixtures = PhotoMap{
 		TypeSrc:          "",
 		PhotoTitle:       "phototobebatchapproved2",
 		TitleSrc:         SrcName,
-		PhotoDescription: "",
+		PhotoDescription: "phototobebatchapproved2",
 		DescriptionSrc:   "",
 		PhotoPath:        "2000/12",
 		PhotoName:        "PhotoToBeBatchApproved2",

--- a/internal/form/search_photos.go
+++ b/internal/form/search_photos.go
@@ -79,6 +79,8 @@ type SearchPhotos struct {
 	Offset    int       `form:"offset" serialize:"-"`                                                                                                                                                                 // Result FILE offset
 	Order     string    `form:"order" serialize:"-"`                                                                                                                                                                  // Sort order
 	Merged    bool      `form:"merged" serialize:"-"`                                                                                                                                                                 // Merge FILES in response
+
+	Description string `form:"description" example:"description:\"Lake*\"" notes:"Description, OR search with |"`
 }
 
 func (f *SearchPhotos) GetQuery() string {

--- a/internal/form/search_photos_geo.go
+++ b/internal/form/search_photos_geo.go
@@ -55,6 +55,9 @@ type SearchPhotosGeo struct {
 	Lens      int       `form:"lens"`
 	Count     int       `form:"count" serialize:"-"`
 	Offset    int       `form:"offset" serialize:"-"`
+
+	// Additional, non-upstreamed filters.
+	Description string `form:"description"`
 }
 
 // GetQuery returns the query parameter as string.

--- a/internal/form/search_photos_test.go
+++ b/internal/form/search_photos_test.go
@@ -91,6 +91,19 @@ func TestParseQueryString(t *testing.T) {
 
 		assert.Equal(t, "123abc/,EFG", form.Path)
 	})
+	t.Run("description", func(t *testing.T) {
+		form := &SearchPhotos{Query: "description:123abc"}
+
+		err := form.ParseQueryString()
+
+		// log.Debugf("%+v\n", form)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, "123abc", form.Description)
+	})
 	t.Run("valid query", func(t *testing.T) {
 		form := &SearchPhotos{Query: "label:cat q:\"fooBar baz\" before:2019-01-15 camera:23 favorite:false dist:25000 lat:33.45343166666667"}
 

--- a/internal/search/photos.go
+++ b/internal/search/photos.go
@@ -486,6 +486,12 @@ func searchPhotos(f form.SearchPhotos, resultCols string) (results PhotoResults,
 		s = s.Where(where, values...)
 	}
 
+	// Filter by photo description?
+	if txt.NotEmpty(f.Description) {
+		where, values := OrLike("photos.photo_description", f.Description)
+		s = s.Where(where, values...)
+	}
+
 	// Filter by file hash?
 	if txt.NotEmpty(f.Hash) {
 		s = s.Where("files.file_hash IN (?)", SplitOr(strings.ToLower(f.Hash)))

--- a/internal/search/photos_geo.go
+++ b/internal/search/photos_geo.go
@@ -323,6 +323,12 @@ func PhotosGeo(f form.SearchPhotosGeo) (results GeoResults, err error) {
 		s = s.Where(where, values...)
 	}
 
+	// Filter by photo description?
+	if f.Description != "" {
+		where, values := OrLike("photos.photo_description", f.Description)
+		s = s.Where(where, values...)
+	}
+
 	// Filter by status?
 	if f.Archived {
 		s = s.Where("photos.photo_quality > -1")

--- a/internal/search/photos_geo_test.go
+++ b/internal/search/photos_geo_test.go
@@ -986,6 +986,24 @@ func TestGeo(t *testing.T) {
 			assert.NotEmpty(t, r.ID)
 		}
 	})
+	t.Run("f.Description = \"photo*\"", func(t *testing.T) {
+		var frm form.SearchPhotosGeo
+
+		frm.Description = "photo*"
+
+		photos, err := PhotosGeo(frm)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.LessOrEqual(t, 1, len(photos))
+
+		for _, r := range photos {
+			assert.IsType(t, GeoResult{}, r)
+			assert.NotEmpty(t, r.ID)
+		}
+	})
 	t.Run("QueryP", func(t *testing.T) {
 		var frm form.SearchPhotosGeo
 		frm.Query = "p"

--- a/internal/search/photos_test.go
+++ b/internal/search/photos_test.go
@@ -519,7 +519,26 @@ func TestPhotos(t *testing.T) {
 
 		//t.Logf("results: %+v", photos)
 		assert.GreaterOrEqual(t, len(photos), 1)
+	})
+	t.Run("form.description", func(t *testing.T) {
+		var f form.SearchPhotos
+		f.Query = "description:*lake"
+		f.Count = 10
+		f.Offset = 0
 
+		// Parse query string and filter.
+		if err := f.ParseQueryString(); err != nil {
+			t.Fatal(err)
+		}
+
+		photos, _, err := Photos(f)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		//t.Logf("results: %+v", photos)
+		assert.GreaterOrEqual(t, len(photos), 1)
 	})
 	t.Run("form.keywords", func(t *testing.T) {
 		var f form.SearchPhotos
@@ -977,6 +996,23 @@ func TestPhotos(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		assert.LessOrEqual(t, 1, len(photos))
+	})
+	t.Run("search for description", func(t *testing.T) {
+		var f form.SearchPhotos
+		f.Description = "*lake"
+
+		// Parse query string and filter.
+		if err := f.ParseQueryString(); err != nil {
+			t.Fatal(err)
+		}
+
+		photos, _, err := Photos(f)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		assert.LessOrEqual(t, 1, len(photos))
 	})
 	t.Run("search for state", func(t *testing.T) {


### PR DESCRIPTION
Using the search filter `description:*Lake` you can now query for photos by their description. If you need to find all photos that even have a description (assuming there is a blank in the text) you can use the following filter: `description:"* *"`