### PR TITLE
Grant family accounts limited access

### DIFF
--- a/internal/acl/permissions.go
+++ b/internal/acl/permissions.go
@@ -16,11 +16,13 @@ var Permissions = ACL{
 	},
 	ResourceAlbums: Roles{
 		RoleAdmin: Actions{ActionDefault: true},
+		RoleFamily: Actions{ActionSearch: true, ActionRead: true},
 		RolePartner: Actions{ActionSearch: true, ActionRead: true},
 		RoleGuest: Actions{ActionSearch: true, ActionRead: true},
 	},
 	ResourcePhotos: Roles{
 		RoleAdmin: Actions{ActionDefault: true},
+		RoleFamily: Actions{ActionSearch: true, ActionRead: true, ActionLike: true},
 		RolePartner: Actions{ActionSearch: true, ActionRead: true, ActionLike: true},
 		RoleGuest: Actions{ActionSearch: true, ActionRead: true, ActionDownload: true},
 	},


### PR DESCRIPTION
As a stop-gap until proper multiuser support is implemented, grant user accounts with the "Family" role limited access to the system. The following actions are granted:
- search and view all types of albums (folders, moments, "smart albums", etc)
- search and view and photos
- like/favorite photos
