### PR TITLE
Provide an expvar endpoint for monitoring

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -27,6 +27,9 @@ func registerRoutes(router *gin.Engine, conf *config.Config) {
 	// Sharing routes start with "/s".
 	registerSharingRoutes(router, conf)
 
+	// Monitoring and debugging endpoints.
+	registerMonitoringRoutes(router, conf)
+
 	// JSON-REST API Version 1
 	// Authentication.
 	api.CreateSession(APIv1)

--- a/internal/server/routes_monitoring.go
+++ b/internal/server/routes_monitoring.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"github.com/gin-contrib/expvar"
+	"github.com/gin-gonic/gin"
+
+	"github.com/photoprism/photoprism/internal/config"
+)
+
+// registerMonitoringRoutes configures debugging and monitoring endpoints.
+func registerMonitoringRoutes(router *gin.Engine, conf *config.Config) {
+
+	// Serves golang metrics.
+	if conf.EnableExpvar() {
+		router.GET("/debug/vars", expvar.Handler())
+	}
+}


### PR DESCRIPTION
With the latest upstream code restructuring, the expvar endpoint was lost in the last merge request.

related to #30 