### PR TITLE
Restore "newest" as default sort order for folders

### DIFF
--- a/frontend/src/app/routes.js
+++ b/frontend/src/app/routes.js
@@ -210,7 +210,7 @@ export default [
     path: "/folders",
     component: Albums,
     meta: { title: $gettext("Folders"), auth: true },
-    props: { view: "folder", defaultOrder: "name", staticFilter: { type: "folder" } },
+    props: { view: "folder", defaultOrder: "newest", staticFilter: { type: "folder" } },
   },
   {
     name: "folder",


### PR DESCRIPTION
In the upstream project the default sort order for folders has been changed to  "name" (from "newest"), which does not fit with my personal preferences.

related to https://github.com/kvalev/photoprism/commit/bc507706848165c4b7ace26fbf14ec68065f26d5, https://github.com/photoprism/photoprism/issues/2050

