### PR TITLE
Fix Web Share in photo viewer

### DIFF
--- a/frontend/src/component/photo-viewer.vue
+++ b/frontend/src/component/photo-viewer.vue
@@ -259,12 +259,12 @@ export default {
     onWebShare() {
       this.onPause();
 
-      if (!this.item || !this.item.download_url) {
+      if (!this.item || !this.item.DownloadUrl) {
         console.warn("photo viewer: no download url");
         return;
       }
 
-      new Photo().find(this.item.uid).then(p => p.webShare()).catch(e => {
+      new Photo().find(this.item.UID).then(p => p.webShare()).catch(e => {
         this.$notify.error("couldn't share photo");
         console.warn(e);
       });


### PR DESCRIPTION
The web share in the photo viewer was broken due to renamed data model properties.

related to #48 
