### PR TITLE
Handle private country albums and country count

### DIFF
--- a/frontend/src/common/config.js
+++ b/frontend/src/common/config.js
@@ -189,6 +189,7 @@ export default class Config {
       this.values.count.moments -= values.count.private_moments;
       this.values.count.months -= values.count.private_months;
       this.values.count.states -= values.count.private_states;
+      this.values.count.countries -= values.count.private_countries;
     }
 
     return this;

--- a/frontend/tests/unit/config.js
+++ b/frontend/tests/unit/config.js
@@ -376,6 +376,7 @@ const clientConfig = {
     private_moments: 0,
     private_months: 0,
     private_states: 0,
+    private_countries: 0,
     review: 22,
     stories: 0,
     albums: 2,

--- a/internal/config/client_config.go
+++ b/internal/config/client_config.go
@@ -158,6 +158,9 @@ type ClientCounts struct {
 	Places         int `json:"places"`
 	Labels         int `json:"labels"`
 	LabelMaxPhotos int `json:"labelMaxPhotos"`
+
+	// Additional attributes
+	PrivateCountries int `json:"private_countries"`
 }
 
 type CategoryLabels []CategoryLabel
@@ -562,8 +565,8 @@ func (c *Config) ClientUser(withSettings bool) ClientConfig {
 		c.Db().
 			Table("albums").
 			Select("SUM(album_type = ?) AS albums, SUM(album_type = ?) AS moments, SUM(album_type = ?) AS months, SUM(album_type = ?) AS states, SUM(album_type = ?) AS countries, SUM(album_type = ?) AS folders, "+
-				"SUM(album_type = ? AND album_private = 1) AS private_albums, SUM(album_type = ? AND album_private = 1) AS private_moments, SUM(album_type = ? AND album_private = 1) AS private_months, SUM(album_type = ? AND album_private = 1) AS private_states, SUM(album_type = ? AND album_private = 1) AS private_folders",
-				entity.AlbumManual, entity.AlbumMoment, entity.AlbumMonth, entity.AlbumState, entity.AlbumCountry, entity.AlbumFolder, entity.AlbumManual, entity.AlbumMoment, entity.AlbumMonth, entity.AlbumState, entity.AlbumFolder).
+				"SUM(album_type = ? AND album_private = 1) AS private_albums, SUM(album_type = ? AND album_private = 1) AS private_moments, SUM(album_type = ? AND album_private = 1) AS private_months, SUM(album_type = ? AND album_private = 1) AS private_states, SUM(album_type = ? AND album_private = 1) AS private_countries, SUM(album_type = ? AND album_private = 1) AS private_folders",
+				entity.AlbumManual, entity.AlbumMoment, entity.AlbumMonth, entity.AlbumState, entity.AlbumCountry, entity.AlbumFolder, entity.AlbumManual, entity.AlbumMoment, entity.AlbumMonth, entity.AlbumState, entity.AlbumCountry, entity.AlbumFolder).
 			Where("deleted_at IS NULL AND (albums.album_type <> 'folder' OR albums.album_path IN (SELECT photos.photo_path FROM photos WHERE photos.photo_private = 0 AND photos.deleted_at IS NULL))").
 			Take(&cfg.Count)
 	} else {

--- a/internal/search/albums.go
+++ b/internal/search/albums.go
@@ -54,6 +54,8 @@ func UserAlbums(f form.SearchAlbums, sess *entity.Session) (results AlbumResults
 			aclResource = acl.ResourceCalendar
 		case entity.AlbumState:
 			aclResource = acl.ResourcePlaces
+		case entity.AlbumCountry:
+			aclResource = acl.ResourcePlaces
 		}
 
 		// Check user permissions.


### PR DESCRIPTION
If a country album has been marked as private (not possible via the UI currently), any users that are not allowed to see private country albums should not be able to see it in the UI and the country count should be deducted.

related to #4 