### PR TITLE
Configurable user authentication provider

### DIFF
--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -32,6 +32,9 @@ RUN wget -qO- https://dl.photoprism.app/qa/demo.tar.gz | tar xvz -C /photoprism/
 # Add my example photos
 COPY /assets/examples/demo /photoprism/originals/demo/my
 
+# Add an additional user
+RUN photoprism user add family --password photoprism --auth local
+
 # Import example photos
 RUN photoprism restore -a && \
     photoprism index -a && \

--- a/internal/commands/users.go
+++ b/internal/commands/users.go
@@ -57,7 +57,7 @@ var UserFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "auth, a",
 		Usage: UserAuthUsage,
-		Value: string(authn.ProviderDefault),
+		Value: string(authn.ProviderLocal),
 	},
 	cli.BoolFlag{
 		Name:  "superadmin, s",

--- a/internal/commands/users.go
+++ b/internal/commands/users.go
@@ -4,6 +4,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/photoprism/photoprism/internal/acl"
+	"github.com/photoprism/photoprism/pkg/authn"
 )
 
 // Usage hints for the user management subcommands.
@@ -12,6 +13,7 @@ const (
 	UserEmailUsage    = "unique `EMAIL` address of the user"
 	UserPasswordUsage = "`PASSWORD` for local authentication"
 	UserRoleUsage     = "user role `NAME` (leave blank for default)"
+	UserAuthUsage     = "authentication provider (leave blank for default)"
 	UserAdminUsage    = "make user super admin with full access"
 	UserNoLoginUsage  = "disable login on the web interface"
 	UserWebDAVUsage   = "allow to sync files via WebDAV"
@@ -51,6 +53,11 @@ var UserFlags = []cli.Flag{
 		Name:  "role, r",
 		Usage: UserRoleUsage,
 		Value: acl.RoleAdmin.String(),
+	},
+	cli.StringFlag{
+		Name:  "auth, a",
+		Usage: UserAuthUsage,
+		Value: string(authn.ProviderDefault),
 	},
 	cli.BoolFlag{
 		Name:  "superadmin, s",

--- a/internal/entity/auth_user_cli.go
+++ b/internal/entity/auth_user_cli.go
@@ -26,6 +26,11 @@ func (m *User) SetValuesFromCli(ctx *cli.Context) error {
 		m.SetRole(frm.Role())
 	}
 
+	// Authentication Provider.
+	if ctx.IsSet("auth") {
+		m.AuthProvider = frm.AuthProvider
+	}
+
 	// Super-admin status.
 	if ctx.IsSet("superadmin") {
 		m.SuperAdmin = frm.SuperAdmin


### PR DESCRIPTION
Make the user authentication provider configurable - both for new users, as well as for existing ones.

CLI examples:
```sh
photoprism user add mom --auth local
photoprism user mod dad -a local
```

Although this should not be needed, as the default authentication provider for new users has been changed from `default` to `local`. The `default` provider is unusable, so having a sensible default will save users a lot of headaches trying to debug why login is not working (login is actually prohibited for the `default` auth provider).