### PR TITLE
Fix search page routing for non-default homepage

### DIFF
--- a/frontend/src/app/routes.js
+++ b/frontend/src/app/routes.js
@@ -149,7 +149,7 @@ export default [
     beforeEnter: (to, from, next) => {
       if (session.loginRequired()) {
         next({ name: "login" });
-      } else if (to.name !== homepage()) {
+      } else if (!from.name && homepage() !== "browse") {
         // Prevent recursive redirects
         next({ name: homepage() });
       } else {


### PR DESCRIPTION
In case the user set a non-default homepage (meaning not the search page), the routing was broken and prevented the user from navigating to the search page.

related to #107, #103, #74