### PR TITLE
Create family role and align `like` permissions

### DIFF
--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -33,7 +33,7 @@ RUN wget -qO- https://dl.photoprism.app/qa/demo.tar.gz | tar xvz -C /photoprism/
 COPY /assets/examples/demo /photoprism/originals/demo/my
 
 # Add an additional user
-RUN photoprism user add family --password photoprism --auth local
+RUN photoprism user add family --password photoprism --role family --auth local
 
 # Import example photos
 RUN photoprism restore -a && \

--- a/frontend/src/common/config.js
+++ b/frontend/src/common/config.js
@@ -431,6 +431,17 @@ export default class Config {
     return !this.allowAny(resource, perm);
   }
 
+  canLike() {
+    // There are a lot of inconsistencies in the upstream project about who can like/favorite and react to photos.
+    // The backend requires photos/update for liking a photo and photos/react for reacting to media.
+    // The frontend mostly requires a different permission - photos/manage. All of the different photo views -
+    // cards, mosaic and list require photos/manage. However, the photoviewer additionally requires the "favorites"
+    // feature and the favorites/search permission.
+    // In order to simplify all that, let's stick with the permissions required by the backend - photos/update or
+    // photos/react.
+    return this.allowAny("photos", ["update", "react"]);
+  }
+
   settings() {
     return this.values.settings;
   }

--- a/frontend/src/component/photo-viewer.vue
+++ b/frontend/src/component/photo-viewer.vue
@@ -101,8 +101,8 @@ export default {
   name: "PPhotoViewer",
   data() {
     return {
+      canLike: this.$config.canLike(),
       canEdit: this.$config.allow("photos", "update") && this.$config.feature("edit"),
-      canLike: this.$config.allow("photos", "manage") && this.$config.feature("favorites"),
       canDownload: this.$config.allow("photos", "download") && this.$config.feature("download"),
       selection: this.$clipboard.selection,
       config: this.$config.values,

--- a/frontend/src/component/photo/cards.vue
+++ b/frontend/src/component/photo/cards.vue
@@ -148,7 +148,7 @@
             </button>
 
             <button
-                  v-if="!isSharedView"
+                  v-if="!isSharedView || $config.canLike()"
                   class="input-favorite"
                   @touchstart.stop.prevent="input.touchStart($event, index)"
                   @touchend.stop.prevent="toggleLike($event, index)"

--- a/frontend/src/component/photo/list.vue
+++ b/frontend/src/component/photo/list.vue
@@ -109,7 +109,7 @@
                   {{ photo.locationInfo() }}
                 </span>
               </td>
-              <template v-if="!isSharedView">
+              <template v-if="!isSharedView || $config.canLike()">
                 <td class="text-xs-center">
                   <template v-if="index < firstVisibleElementIndex || index > lastVisibileElementIndex">
                     <div v-if="hidePrivate" class="v-btn v-btn--icon v-btn--small" />

--- a/frontend/src/component/photo/mosaic.vue
+++ b/frontend/src/component/photo/mosaic.vue
@@ -115,7 +115,7 @@
               <i color="white" class="select-off">radio_button_off</i>
             </button>
 
-            <button v-if="!isSharedView"
+            <button v-if="!isSharedView || $config.canLike()"
                 class="input-favorite"
                 @touchstart.stop.prevent="input.touchStart($event, index)"
                 @touchend.stop.prevent="toggleLike($event, index)"

--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -361,11 +361,11 @@ body.chrome #photoprism .search-results .result {
     display: none;
 }
 
-#photoprism .disable-manage .search-results .result:not(.is-favorite) .input-favorite {
+#photoprism .disable-update .search-results .result:not(.is-favorite) .input-favorite {
     visibility: hidden;
 }
 
-#photoprism .disable-manage .search-results .result .input-favorite.v-btn:before {
+#photoprism .disable-update .search-results .result .input-favorite.v-btn:before {
     visibility: hidden;
 }
 

--- a/internal/acl/acl_events.go
+++ b/internal/acl/acl_events.go
@@ -3,14 +3,17 @@ package acl
 // Events specifies granted permissions by event channel and Role.
 var Events = ACL{
 	ResourceDefault: Roles{
-		RoleAdmin: GrantFullAccess,
+		RoleAdmin:  GrantFullAccess,
+		RoleFamily: GrantSubscribeOwn,
 	},
 	ChannelUser: Roles{
 		RoleAdmin:   GrantFullAccess,
+		RoleFamily:  GrantSubscribeOwn,
 		RoleVisitor: GrantSubscribeOwn,
 	},
 	ChannelSession: Roles{
 		RoleAdmin:   GrantFullAccess,
+		RoleFamily:  GrantSubscribeOwn,
 		RoleVisitor: GrantSubscribeOwn,
 	},
 }

--- a/internal/acl/acl_resources.go
+++ b/internal/acl/acl_resources.go
@@ -7,40 +7,50 @@ var Resources = ACL{
 	},
 	ResourcePhotos: Roles{
 		RoleAdmin:   GrantFullAccess,
+		RoleFamily:  GrantReadOnlyReact,
 		RoleVisitor: Grant{AccessShared: true, ActionView: true, ActionDownload: true},
 	},
 	ResourceVideos: Roles{
 		RoleAdmin:   GrantFullAccess,
+		RoleFamily:  GrantReadOnly,
 		RoleVisitor: Grant{AccessShared: true, ActionView: true, ActionDownload: true},
 	},
 	ResourceAlbums: Roles{
 		RoleAdmin:   GrantFullAccess,
+		RoleFamily:  GrantReadOnly,
 		RoleVisitor: GrantSearchShared,
 	},
 	ResourceFolders: Roles{
 		RoleAdmin:   GrantFullAccess,
+		RoleFamily:  GrantReadOnly,
 		RoleVisitor: GrantSearchShared,
 	},
 	ResourcePlaces: Roles{
 		RoleAdmin:   GrantFullAccess,
+		RoleFamily:  GrantReadOnly,
 		RoleVisitor: Grant{AccessShared: true, ActionView: true, ActionDownload: true},
 	},
 	ResourceCalendar: Roles{
 		RoleAdmin:   GrantFullAccess,
+		RoleFamily:  GrantReadOnly,
 		RoleVisitor: GrantSearchShared,
 	},
 	ResourceMoments: Roles{
 		RoleAdmin:   GrantFullAccess,
+		RoleFamily:  GrantReadOnly,
 		RoleVisitor: GrantSearchShared,
 	},
 	ResourcePeople: Roles{
-		RoleAdmin: GrantFullAccess,
+		RoleAdmin:  GrantFullAccess,
+		RoleFamily: GrantReadOnly,
 	},
 	ResourceFavorites: Roles{
-		RoleAdmin: GrantFullAccess,
+		RoleAdmin:  GrantFullAccess,
+		RoleFamily: GrantReadOnly,
 	},
 	ResourceLabels: Roles{
-		RoleAdmin: GrantFullAccess,
+		RoleAdmin:  GrantFullAccess,
+		RoleFamily: GrantReadOnly,
 	},
 	ResourceLogs: Roles{
 		RoleAdmin: GrantFullAccess,
@@ -53,7 +63,8 @@ var Resources = ACL{
 		RoleAdmin: GrantFullAccess,
 	},
 	ResourcePassword: Roles{
-		RoleAdmin: GrantFullAccess,
+		RoleAdmin:  GrantFullAccess,
+		RoleFamily: GrantChangePassword,
 	},
 	ResourceShares: Roles{
 		RoleAdmin: GrantFullAccess,
@@ -65,7 +76,8 @@ var Resources = ACL{
 		RoleAdmin: Grant{AccessAll: true, AccessOwn: true, ActionView: true, ActionCreate: true, ActionUpdate: true, ActionDelete: true, ActionSubscribe: true},
 	},
 	ResourceConfig: Roles{
-		RoleAdmin: GrantFullAccess,
+		RoleAdmin:  GrantFullAccess,
+		RoleFamily: GrantLoginOnly,
 	},
 	ResourceDefault: Roles{
 		RoleAdmin: GrantFullAccess,

--- a/internal/acl/grant.go
+++ b/internal/acl/grant.go
@@ -11,11 +11,11 @@ var (
 	// In order to like and react to a photo, the following permissions are needed in addition to the read-only ones:
 	//   - manage: used determine whether the "like/favorite" button will be shown
 	//   - update: required to be able to "like" a photo
-	//   - update: required to be able to use the experimental "react" feature
+	//   - react:  required to be able to use the experimental "react" feature
 	GrantLoginOnly      = Grant{AccessOwn: true}
 	GrantChangePassword = Grant{ActionUpdate: true}
 	GrantReadOnly       = GrantSearchShared.Plus(Grant{AccessLibrary: true})
-	GrantReadOnlyReact  = GrantReadOnly.Plus(Grant{ActionReact: true, ActionManage: true, ActionUpdate: true})
+	GrantReadOnlyReact  = GrantReadOnly.Plus(Grant{ActionReact: true, ActionUpdate: true})
 )
 
 // Grant represents permissions granted or denied.

--- a/internal/acl/grant.go
+++ b/internal/acl/grant.go
@@ -6,6 +6,16 @@ var (
 	GrantSearchShared = Grant{AccessShared: true, ActionSearch: true, ActionView: true, ActionDownload: true}
 	GrantSubscribeAll = Grant{AccessAll: true, ActionSubscribe: true}
 	GrantSubscribeOwn = Grant{AccessOwn: true, ActionSubscribe: true}
+
+	// Custom, family role related permissions.
+	// In order to like and react to a photo, the following permissions are needed in addition to the read-only ones:
+	//   - manage: used determine whether the "like/favorite" button will be shown
+	//   - update: required to be able to "like" a photo
+	//   - update: required to be able to use the experimental "react" feature
+	GrantLoginOnly      = Grant{AccessOwn: true}
+	GrantChangePassword = Grant{ActionUpdate: true}
+	GrantReadOnly       = GrantSearchShared.Plus(Grant{AccessLibrary: true})
+	GrantReadOnlyReact  = GrantReadOnly.Plus(Grant{ActionReact: true, ActionManage: true, ActionUpdate: true})
 )
 
 // Grant represents permissions granted or denied.
@@ -20,4 +30,16 @@ func (grant Grant) Allow(perm Permission) bool {
 	}
 
 	return false
+}
+
+// Plus creates a new grant by adding up all permissions.
+func (grant Grant) Plus(updated Grant) Grant {
+	merged := make(Grant)
+	for k, v := range grant {
+		merged[k] = v
+	}
+	for k, v := range updated {
+		merged[k] = v
+	}
+	return merged
 }

--- a/internal/acl/roles.go
+++ b/internal/acl/roles.go
@@ -5,6 +5,7 @@ const (
 	RoleDefault Role = "default"
 	RoleAdmin   Role = "admin"
 	RoleVisitor Role = "visitor"
+	RoleFamily  Role = "family"
 	RoleUnknown Role = ""
 )
 
@@ -15,6 +16,7 @@ type RoleStrings = map[string]Role
 var ValidRoles = RoleStrings{
 	string(RoleAdmin):   RoleAdmin,
 	string(RoleVisitor): RoleVisitor,
+	string(RoleFamily):  RoleFamily,
 	string(RoleUnknown): RoleUnknown,
 }
 


### PR DESCRIPTION
Add a new role to be used by family members. It provides a read only to the instance - photos, moments, places, calendar, people. The role also grants one "edit" permission - to like photos, the reason being to simplify selecting the best vacation shots.

Additionally this PR tries to bring a bit of consistency with respect to the required permissions for liking a photo, as almost every component in the upstream project requires different permissions. This has now been cleaned up by aligning the frontend permissions to the backend ones. 

related to #95 