### PR TITLE
Show the user profile page when the account feature is on

### DIFF
--- a/frontend/src/component/navigation.vue
+++ b/frontend/src/component/navigation.vue
@@ -561,7 +561,7 @@
           </v-list-tile-content>
         </v-list-tile>
 
-        <v-list-tile v-show="auth && !isPublic && $config.feature('settings')" class="p-profile" @click.stop="onAccount">
+        <v-list-tile v-show="auth && !isPublic && $config.feature('account')" class="p-profile" @click.stop="onAccount">
           <v-list-tile-avatar size="36">
             <img :src="userAvatarURL" :alt="accountInfo" :title="accountInfo">
           </v-list-tile-avatar>


### PR DESCRIPTION
The upstream project erroneously uses the "settings" feature to determine whether the profile page should be visible or not. Especially when the mobile menu uses the "account" feature as well.
