### PR TITLE
Add photosphere search filters 

### DIFF
--- a/internal/form/search_photos.go
+++ b/internal/form/search_photos.go
@@ -13,7 +13,7 @@ type SearchPhotos struct {
 	Filter    string    `form:"filter" serialize:"-" notes:"-"`
 	ID        string    `form:"id" example:"id:123e4567-e89b-..." notes:"Finds pictures by Exif UID, XMP Document ID or Instance ID"`
 	UID       string    `form:"uid" example:"uid:pqbcf5j446s0futy" notes:"Limits results to the specified internal unique IDs"`
-	Type      string    `form:"type" example:"type:raw" notes:"Media Type (image, video, raw, live, animated); OR search with |"`
+	Type      string    `form:"type" example:"type:raw" notes:"Media Type (image, video, raw, live, sphere, animated); OR search with |"`
 	Path      string    `form:"path" example:"path:2020/Holiday" notes:"Path Name, OR search with |, supports * wildcards"`
 	Folder    string    `form:"folder" example:"folder:\"*/2020\"" notes:"Path Name, OR search with |, supports * wildcards"` // Alias for Path
 	Name      string    `form:"name" example:"name:\"IMG_9831-112*\"" notes:"File Name without path and extension, OR search with |"`
@@ -83,6 +83,8 @@ type SearchPhotos struct {
 	Offset    int       `form:"offset" serialize:"-"`                                                                                                                                                                 // Result FILE offset
 	Order     string    `form:"order" serialize:"-"`                                                                                                                                                                  // Sort order
 	Merged    bool      `form:"merged" serialize:"-"`                                                                                                                                                                 // Merge FILES in response
+
+	Sphere    bool      `form:"sphere" notes:"Finds Photosphere Photos"`
 }
 
 func (f *SearchPhotos) GetQuery() string {

--- a/internal/search/photos.go
+++ b/internal/search/photos.go
@@ -541,8 +541,10 @@ func searchPhotos(f form.SearchPhotos, sess *entity.Session, resultCols string) 
 		s = s.Where("photos.photo_type = ?", entity.MediaRaw)
 	} else if f.Live {
 		s = s.Where("photos.photo_type = ?", entity.MediaLive)
+	} else if f.Sphere {
+		s = s.Where("photos.photo_type = ?", entity.MediaSphere)
 	} else if f.Photo {
-		s = s.Where("photos.photo_type IN ('image','live','animated','vector','raw')")
+		s = s.Where("photos.photo_type IN ('image','live','sphere','animated','vector','raw')")
 	}
 
 	// Filter by storage path.

--- a/pkg/media/type.go
+++ b/pkg/media/type.go
@@ -25,7 +25,7 @@ func (t Type) NotEqual(s string) bool {
 // Main checks if this is a known main media content format.
 func (t Type) Main() bool {
 	switch t {
-	case Image, Raw, Animated, Live, Video, Vector:
+	case Image, Raw, Animated, Live, Sphere, Video, Vector:
 		return true
 	default:
 		return false


### PR DESCRIPTION
Photosphere images can now be found using the following filters:
- `type:sphere` (or for example `type:live|sphere`)
- `sphere:yes`

Additionally photosphere images will be shown when the user searches for photos using `photos:yes`.