### PR TITLE
Check album permissions when setting a cover

### DIFF
--- a/frontend/src/component/photo/clipboard.vue
+++ b/frontend/src/component/photo/clipboard.vue
@@ -135,7 +135,7 @@
           <v-icon>eject</v-icon>
         </v-btn>
         <v-btn
-            v-if="canEdit && album && context !== 'archive'" fab dark
+            v-if="canEditAlbum && album && context !== 'archive'" fab dark
             small
             :title="$gettext('Set as cover')"
             color="cover"
@@ -433,7 +433,7 @@ export default {
       this.clearClipboard();
     },
     setCover() {
-      if (!this.canEdit) {
+      if (!this.canEditAlbum) {
         return;
       }
 


### PR DESCRIPTION
The required permission for setting an album/label/person cover has been changed from photos/update to albums/update, which is also the permission used by the backend.

related to #2 