### PR TITLE
Consider permissions when counting photos in smart albums

### DIFF
--- a/internal/search/albums.go
+++ b/internal/search/albums.go
@@ -265,7 +265,7 @@ func UserAlbums(f form.SearchAlbums, sess *entity.Session) (results AlbumResults
 				return results, err
 			}
 
-			_, count, err := PhotoIds(f)
+			_, count, err := UserPhotoIds(f, sess)
 			if err != nil {
 				return results, err
 			}

--- a/internal/search/photos.go
+++ b/internal/search/photos.go
@@ -21,6 +21,7 @@ import (
 
 // PhotosColsAll contains all supported result column names.
 var PhotosColsAll = SelectString(Photo{}, []string{"*"})
+var PhotosColsIds = "photos.id, photos.photo_uid, files.file_uid"
 
 // PhotosColsView contains the result column names necessary for the photo viewer.
 var PhotosColsView = SelectString(Photo{}, SelectCols(GeoResult{}, []string{"*"}))
@@ -42,7 +43,12 @@ func UserPhotos(f form.SearchPhotos, sess *entity.Session) (results PhotoResults
 func PhotoIds(f form.SearchPhotos) (files PhotoResults, count int, err error) {
 	f.Merged = false
 	f.Primary = true
-	return searchPhotos(f, nil, "photos.id, photos.photo_uid, files.file_uid")
+	return searchPhotos(f, nil, PhotosColsIds)
+}
+
+// UserPhotoIds finds photo and file ids based on the search form and user session.
+func UserPhotoIds(f form.SearchPhotos, sess *entity.Session) (results PhotoResults, count int, err error) {
+	return searchPhotos(f, sess, PhotosColsIds)
 }
 
 // searchPhotos finds photos based on the search form and user session then returns them as PhotoResults.


### PR DESCRIPTION
The previous photo count query did not take user permissions and private photos into account and they were erroneously counted.

related to #71 