### PR TITLE
Fix setting a person thumbnail

### DIFF
--- a/frontend/src/page/photos.vue
+++ b/frontend/src/page/photos.vue
@@ -216,9 +216,9 @@ export default {
 
     // Supported contexts: label, person, subject
     const supportedTypes = {
-      "label": [Label, this.filter.label],
-      "person": [Subject, this.filter.person],
-      "subject": [Subject, this.filter.subject],
+      "label": [Label, this.filter.label, "q"],
+      "person": [Subject, this.filter.person, "name"],
+      "subject": [Subject, this.filter.subject, "name"],
     }
 
     // Find all used filters to determine the current context (and exclude the sort order).
@@ -227,9 +227,9 @@ export default {
     // If we have encountered only one of the supported contexts,
     // we can essentially treat the current view as an album (even thought it is not).
     if (activeFilters.length == 1) {
-      const [Type, filter] = supportedTypes[activeFilters[0]];
+      const [Type, filter, q] = supportedTypes[activeFilters[0]];
 
-      Type.search({q: filter, count: 1}).then(response => this.labelOrSubjectAlbum = response.models[0]);
+      Type.search({[q]: filter, count: 1}).then(response => this.labelOrSubjectAlbum = response.models[0]);
     }
 
     this.subscriptions.push(Event.subscribe("import.completed", (ev, data) => this.onImportCompleted(ev, data)));

--- a/internal/search/subjects.go
+++ b/internal/search/subjects.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gosimple/slug"
 	"github.com/photoprism/photoprism/pkg/clean"
 
 	"github.com/photoprism/photoprism/pkg/txt"
@@ -54,6 +55,11 @@ func Subjects(f form.SearchSubjects) (results SubjectResults, err error) {
 		}
 
 		return results, nil
+	}
+
+	if f.Name != "" {
+		// Some views pass the slug as name, so we need to account for that.
+		s = s.Where("subj_name = ? OR subj_slug = ?", f.Name, slug.Make(f.Name))
 	}
 
 	if f.Query != "" {


### PR DESCRIPTION
I guess at some point something must have changed, as it was not possible selecting a new thumbnail for a person/subject. Additionally the person/subject lookup had to be changed from using query (q) to using the name/slug. This was needed, as the q-based query can return the wrong subject. Due to the q-query using LIKE terms, it can match subjects, which are named similar to the currently open subject, for example Pete and Peter. In order to avoid that, the subject lookup now uses a name/slug based query.

related to #76 