### PR TITLE
Show tagged subjects for albums

### DIFF
--- a/frontend/src/css/results.css
+++ b/frontend/src/css/results.css
@@ -487,6 +487,10 @@ body.chrome #photoprism .search-results .result {
     border-bottom-right-radius: 6px;
 }
 
+#photoprism .cards-view .card .card-details .subject-avatar {
+    margin-right: 3px;
+}
+
 #photoprism .cards-view .v-card .card-details {
     z-index: 1;
     position: relative;

--- a/frontend/src/model/album.js
+++ b/frontend/src/model/album.js
@@ -24,6 +24,7 @@ Additional information can be found in our Developer Guide:
 */
 
 import RestModel from "model/rest";
+import Subject from "model/subject";
 import Api from "common/api";
 import countries from "options/countries.json";
 import { DateTime } from "luxon";
@@ -62,6 +63,7 @@ export class Album extends RestModel {
       LinkCount: 0,
       CreatedAt: "",
       UpdatedAt: "",
+      Subjects: [],
     };
   }
 
@@ -208,6 +210,14 @@ export class Album extends RestModel {
   unlike() {
     this.Favorite = false;
     return Api.delete(this.getEntityResource() + "/like");
+  }
+
+  hasSubjects() {
+    return this.Subjects !== undefined && this.Subjects !== null && this.Subjects.length > 0;
+  }
+
+  getSubjects() {
+    return this.hasSubjects() ? this.Subjects.map((s) => new Subject(s)) : [];
   }
 
   static batchSize() {

--- a/frontend/src/page/albums.vue
+++ b/frontend/src/page/albums.vue
@@ -235,6 +235,11 @@
                     {{ album.getLocation() }}
                   </button>
                 </div>
+                <div v-if="album.hasSubjects()" class="caption mb-2" :title="$gettext('Subjects')">
+                  <v-avatar v-for="subject in album.getSubjects()" :key="subject.UID" :size="25" class="subject-avatar">
+                    <img :src="subject.thumbnailUrl('tile_50')" :alt="subject.Name">
+                  </v-avatar>
+                </div>
               </v-card-text>
             </v-card>
           </v-flex>

--- a/internal/api/albums_search.go
+++ b/internal/api/albums_search.go
@@ -53,6 +53,12 @@ func SearchAlbums(router *gin.RouterGroup) {
 			return
 		}
 
+		if settings.Features.People && get.Config().Experimental() {
+			if err := result.LoadAlbumsSubjects(s); err != nil {
+				log.Errorf("albums: %s (loading album faces)", err)
+			}
+		}
+
 		AddCountHeader(c, len(result))
 		AddLimitHeader(c, f.Count)
 		AddOffsetHeader(c, f.Offset)

--- a/internal/search/albums_faces.go
+++ b/internal/search/albums_faces.go
@@ -1,0 +1,44 @@
+package search
+
+import (
+	"github.com/dustin/go-humanize/english"
+	"github.com/photoprism/photoprism/internal/entity"
+	"github.com/photoprism/photoprism/internal/form"
+	"github.com/photoprism/photoprism/pkg/txt"
+)
+
+// LoadAlbumsSubjects populates the subjects which have been tagged in photos belonging to the given albums.
+// All types of albums are supported - plain ones, folders, moment, state, country, as well as smart albums.
+// However be aware that the queries are very suboptimal.
+func (albums AlbumResults) LoadAlbumsSubjects(sess *entity.Session) error {
+	for i := 0; i < len(albums); i++ {
+
+		f := form.SearchPhotos{
+			Album: albums[i].AlbumUID,
+			Filter: albums[i].AlbumFilter,
+		}
+
+		if err := f.ParseQueryString(); err != nil {
+			return err
+		}
+
+		photos, count, err := UserPhotos(f, sess)
+
+		if err != nil {
+			return err
+		}
+
+		if count == 0 {
+			return nil
+		}
+
+		if subjects, err := photos.Subjects(); err != nil {
+			return err
+		} else {
+			log.Debugf("albums: %s has %s (%s)", albums[i].AlbumTitle, english.Plural(len(subjects), "subject", "subjects"), txt.UniqueNames(subjects.Names()))
+			albums[i].Subjects = subjects
+		}
+	}
+
+	return nil
+}

--- a/internal/search/albums_results.go
+++ b/internal/search/albums_results.go
@@ -35,6 +35,8 @@ type Album struct {
 	CreatedAt        time.Time `json:"CreatedAt"`
 	UpdatedAt        time.Time `json:"UpdatedAt"`
 	DeletedAt        time.Time `json:"DeletedAt,omitempty"`
+
+	Subjects SubjectResults `json:"Subjects"`
 }
 
 type AlbumResults []Album

--- a/internal/search/photos_subjects.go
+++ b/internal/search/photos_subjects.go
@@ -1,0 +1,20 @@
+package search
+
+import (
+	"github.com/photoprism/photoprism/internal/entity"
+)
+
+// Subjects finds all subjects associated with the given photo results.
+func (photos PhotoResults) Subjects() (results SubjectResults, err error) {
+	s := UnscopedDb().Table(entity.Subject{}.TableName()).
+		Select("DISTINCT subjects.*").
+		Joins("LEFT JOIN markers m on subjects.subj_uid = m.subj_uid").
+		Joins("LEFT JOIN files f on m.file_uid = f.file_uid").
+		Where("m.marker_type = ? AND f.photo_uid IN (?)", entity.MarkerFace, photos.UIDs())
+
+	if result := s.Scan(&results); result.Error != nil {
+		return results, result.Error
+	}
+
+	return results, nil
+}

--- a/internal/search/subjects_results.go
+++ b/internal/search/subjects_results.go
@@ -21,3 +21,14 @@ type Subject struct {
 
 // SubjectResults represents subject search results.
 type SubjectResults []Subject
+
+// Names returns a slice of subject names.
+func (subjects SubjectResults) Names() []string {
+	result := make([]string, len(subjects))
+
+	for i, el := range subjects {
+		result[i] = el.SubjName
+	}
+
+	return result
+}


### PR DESCRIPTION
This is an experimental feature, which will show all tagged subjects for all album types (manual, folders, moments, months, states, countries).

<img width="241" alt="Screenshot 2023-05-15 at 03 04 05" src="https://github.com/kvalev/photoprism/assets/270592/82999411-ef60-4bd0-b253-5657085c6099">

related to https://github.com/photoprism/photoprism/issues/1578
