### PR TITLE
Basic plugin system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,9 @@ build-race:
 build-static:
 	rm -f $(BINARY_NAME)
 	scripts/build.sh static $(BINARY_NAME)
+build-plugin-demo:
+	mkdir -p storage/plugins
+	go build -buildmode=plugin -o storage/plugins/demo.so internal/plugin/demo/demo.go
 build-tensorflow:
 	docker build -t photoprism/tensorflow:build docker/tensorflow
 	docker run -ti photoprism/tensorflow:build bash

--- a/internal/config/config_filepaths.go
+++ b/internal/config/config_filepaths.go
@@ -342,7 +342,7 @@ func (c *Config) UsersOriginalsPath() string {
 
 // UsersStoragePath returns the users storage base path.
 func (c *Config) UsersStoragePath() string {
-	return filepath.Join(c.StoragePath(), "users")
+	return filepath.Join(c.StoragePath(), c.UsersPath())
 }
 
 // UserStoragePath returns the storage path for user assets.
@@ -614,4 +614,9 @@ func (c *Config) AlbumsPath() string {
 // OriginalsAlbumsPath returns the optional album YAML file path inside originals.
 func (c *Config) OriginalsAlbumsPath() string {
 	return filepath.Join(c.OriginalsPath(), "albums")
+}
+
+// PluginsPath returns the absolute path where plugin solibs should be located.
+func (c *Config) PluginsPath() string {
+	return filepath.Join(c.StoragePath(), "plugins")
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -786,6 +786,6 @@ var Flags = CliFlags{
 		Flag: cli.BoolFlag{
 			Name:   "enable-expvar",
 			Usage:  "provide a publicly accessible expvar endpoint",
-			EnvVar: "PHOTOPRISM_ENABLE_EXPVAR",
+			EnvVar: EnvVar("ENABLE_EXPVAR"),
 		}},
 }

--- a/internal/photoprism/index.go
+++ b/internal/photoprism/index.go
@@ -19,6 +19,7 @@ import (
 	"github.com/photoprism/photoprism/internal/i18n"
 	"github.com/photoprism/photoprism/internal/mutex"
 	"github.com/photoprism/photoprism/internal/nsfw"
+	"github.com/photoprism/photoprism/internal/plugin"
 	"github.com/photoprism/photoprism/pkg/clean"
 	"github.com/photoprism/photoprism/pkg/fs"
 	"github.com/photoprism/photoprism/pkg/media"
@@ -104,6 +105,9 @@ func (ind *Index) Start(o IndexOptions) (found fs.Done, updated int) {
 		event.InfoMsg(i18n.ErrOriginalsEmpty)
 		return found, updated
 	}
+
+	// Load plugins.
+	plugin.LoadPlugins(ind.conf.PluginsPath())
 
 	if err := mutex.MainWorker.Start(); err != nil {
 		event.Error(fmt.Sprintf("index: %s", err.Error()))

--- a/internal/plugin/README.md
+++ b/internal/plugin/README.md
@@ -1,0 +1,39 @@
+# Plugins
+
+This package provides the infrastructure for registering PhotoPrism plugins.
+
+Currently the plugin system provides hooks into the following internals:
+
+- `indexing`: Allowing to run different tagging and face detection algorithms or adding and modifying media metadata.
+
+## Implementation
+
+Check the demo plugin implementation in [plugin.go](./demo/plugin.go) and the `build-plugin-demo` make target in the [Makefile](../../Makefile) on how to compile the plugin solib.
+
+## Configuration
+
+The plugin can be configured using environment variables, which will be passed as key-value pairs to the plugin's `Configure` method.
+All configuration parameters will be namespaced and the plugin will only have access to the variables prefixed with `PHOTOPRISM_PLUGIN_[UPPERCASE_PLUGIN_NAME]_`. The prefix will be stripped from the resulting parameters and the the rest of the parameter key will be lowercased.
+
+For example a `demo` plugin might need a hostname and a port as configuration parameters, which can be achieved using the following environment variables:
+
+```sh
+PHOTOPRISM_PLUGIN_DEMO_HOSTNAME=localhost
+PHOTOPRISM_PLUGIN_DEMO_PORT=1234
+```
+
+This configuration will then be passed to the plugin as the following key-value pairs:
+
+```go
+map[string]string{"hostname": "localhost", "port": "1234"}
+```
+
+This way you can safely pass any configuration parameters to your plugin.
+
+## Activation
+
+PhotoPrism will look in the `plugins` folder within the `PHOTOPRISM_STORAGE_PATH` folder and load all solib (.so) files found there. In order for the plugin to be loaded, it needs to fulfill few criterias:
+
+- There should be `Plugin` variable that exposes the plugin implementation.
+- Your plugin must implement all of the required interface method, even if you dont use them.
+- Your plugin must be explicitly activated using the `active` configuration parameter: `PHOTOPRISM_PLUGIN_[UPPERCASE_PLUGIN_NAME]_ACTIVE=yes/true/on/enable`.

--- a/internal/plugin/README.md
+++ b/internal/plugin/README.md
@@ -36,4 +36,4 @@ PhotoPrism will look in the `plugins` folder within the `PHOTOPRISM_STORAGE_PATH
 
 - There should be `Plugin` variable that exposes the plugin implementation.
 - Your plugin must implement all of the required interface method, even if you dont use them.
-- Your plugin must be explicitly activated using the `active` configuration parameter: `PHOTOPRISM_PLUGIN_[UPPERCASE_PLUGIN_NAME]_ACTIVE=yes/true/on/enable`.
+- Your plugin must be explicitly activated using the `enabled` configuration parameter: `PHOTOPRISM_PLUGIN_[UPPERCASE_PLUGIN_NAME]_ENABLED=yes/true/on/enable`.

--- a/internal/plugin/config.go
+++ b/internal/plugin/config.go
@@ -1,0 +1,47 @@
+package plugin
+
+import (
+	"fmt"
+	"strings"
+	"os"
+
+	"github.com/photoprism/photoprism/pkg/list"
+)
+
+const (
+	KeyActive = "active"
+)
+
+// PluginConfig is a type alias for a key-value based plugin configuration.
+type PluginConfig map[string]string
+
+// Active checks whether the plugin has been explicitly activated by the used.
+func (c PluginConfig) Active() bool {
+	if value, ok := c[KeyActive]; ok {
+		return list.Bool[strings.ToLower(value)] == list.True
+	}
+
+	// All plugins are disabled per default and only activated if explicitly enabled.
+	return false
+}
+
+func loadConfig(p Plugin) PluginConfig {
+	var config = make(PluginConfig)
+
+	prefix := fmt.Sprintf("PHOTOPRISM_PLUGIN_%s_", strings.ToUpper(p.Name()))
+
+	for _, e := range os.Environ() {
+		pair := strings.SplitN(e, "=", 2)
+
+		key := pair[0]
+		value := pair[1]
+
+		if strings.HasPrefix(key, prefix) {
+			key = strings.ToLower(key[len(prefix):])
+
+			config[key] = value
+		}
+	}
+
+	return config
+}

--- a/internal/plugin/config.go
+++ b/internal/plugin/config.go
@@ -9,15 +9,15 @@ import (
 )
 
 const (
-	KeyActive = "active"
+	KeyEnable = "enabled"
 )
 
 // PluginConfig is a type alias for a key-value based plugin configuration.
 type PluginConfig map[string]string
 
-// Active checks whether the plugin has been explicitly activated by the used.
-func (c PluginConfig) Active() bool {
-	if value, ok := c[KeyActive]; ok {
+// Enabled checks whether the plugin has been explicitly enabled by the used.
+func (c PluginConfig) Enabled() bool {
+	if value, ok := c[KeyEnable]; ok {
 		return list.Bool[strings.ToLower(value)] == list.True
 	}
 

--- a/internal/plugin/demo/demo.go
+++ b/internal/plugin/demo/demo.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/photoprism/photoprism/internal/entity"
+	"github.com/photoprism/photoprism/internal/plugin"
+)
+
+type DemoPlugin struct{}
+
+func (p DemoPlugin) Name() string {
+	return "demo"
+}
+
+func (DemoPlugin) Configure(plugin.PluginConfig) error {
+	return nil
+}
+
+func (DemoPlugin) OnIndex(file *entity.File, photo *entity.Photo) error {
+	photo.Details.Notes = "hello from demo plugin"
+	photo.Details.NotesSrc = entity.SrcManual
+
+	return nil
+}
+
+
+// Export the plugin.
+var Plugin DemoPlugin

--- a/internal/plugin/interface.go
+++ b/internal/plugin/interface.go
@@ -1,0 +1,32 @@
+package plugin
+
+import (
+	"strings"
+
+	"github.com/photoprism/photoprism/internal/entity"
+)
+
+// Plugins is a type alias for a collection of plugins.
+type Plugins []Plugin
+
+// Plugin represents a plugin interface to hook into PhotoPrism's internals.
+// The interface requires specifying a plugin name, a way to configure the plugin using
+// environment variables and various calback hooks.
+type Plugin interface {
+	Name() string
+	Configure(PluginConfig) error
+	OnIndex(*entity.File, *entity.Photo) error
+}
+
+// OnIndex calls the [OnIndex] hook method for all active plugins.
+func OnIndex(file *entity.File, photo *entity.Photo) (changed bool) {
+	for _, p := range getPlugins() {
+		if err := p.OnIndex(file, photo); err != nil {
+			log.Errorf("plugin %s: %s (importing file %s)", strings.ToLower(p.Name()), err, file.FileUID)
+		} else {
+			changed = true
+		}
+	}
+
+	return changed
+}

--- a/internal/plugin/interface.go
+++ b/internal/plugin/interface.go
@@ -18,7 +18,7 @@ type Plugin interface {
 	OnIndex(*entity.File, *entity.Photo) error
 }
 
-// OnIndex calls the [OnIndex] hook method for all active plugins.
+// OnIndex calls the [OnIndex] hook method for all enabled plugins.
 func OnIndex(file *entity.File, photo *entity.Photo) (changed bool) {
 	for _, p := range getPlugins() {
 		if err := p.OnIndex(file, photo); err != nil {

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -67,8 +67,8 @@ func LoadPlugins(path string) {
 		pluginName := strings.ToLower(plugin.Name())
 
 		config := loadConfig(plugin)
-		if !config.Active() {
-			log.Warnf("plugin %s: plugin was loaded, but is not active", pluginName)
+		if !config.Enabled() {
+			log.Warnf("plugin %s: plugin was loaded, but is not enabled", pluginName)
 			continue
 		}
 

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -1,0 +1,87 @@
+package plugin
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"plugin"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+var (
+	pluginsInit  sync.Once
+	pluginsMutex sync.Mutex
+	plugins      atomic.Value
+)
+
+func getPlugins() Plugins {
+	pluginsMutex.Lock()
+	p, _ := plugins.Load().(Plugins)
+	pluginsMutex.Unlock()
+	return p
+}
+
+// LoadPlugins loads plugins from the given directory, looking for all solib files in there.
+// Only plugins, which have been activated by configuration parameter will be loaded.
+func LoadPlugins(path string) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Infof("plugins: path does not exist %s", path)
+		return
+	}
+
+	pluginFolder, err := ioutil.ReadDir(path)
+	if err != nil {
+		log.Errorf("plugins: %s (reading plugin path %s)", err, path)
+		return
+	}
+
+	for _, entry := range pluginFolder {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".so") {
+			return
+		}
+
+		pluginPath := filepath.Join(path, entry.Name())
+		log.Debugf("plugins: found plugin file %s", pluginPath)
+
+		plug, err := plugin.Open(pluginPath)
+		if err != nil {
+			log.Errorf("plugins: %s (when opening plugin solib %s)", err, pluginPath)
+			continue
+		}
+
+		symPlugin, err := plug.Lookup("Plugin")
+		if err != nil {
+			log.Errorf("plugins: %s (when looking up plugin symbol in solib %s)", err, pluginPath)
+			continue
+		}
+
+		var plugin Plugin
+		plugin, ok := symPlugin.(Plugin)
+		if !ok {
+			log.Errorf("plugins: %s (unexpected type for plugin symbol in solib %s", err, pluginPath)
+			continue
+		}
+
+		pluginName := strings.ToLower(plugin.Name())
+
+		config := loadConfig(plugin)
+		if !config.Active() {
+			log.Warnf("plugin %s: plugin was loaded, but is not active", pluginName)
+			continue
+		}
+
+		if err := plugin.Configure(config); err != nil {
+			log.Errorf("plugin %s: %s (plugin configuration)", pluginName, err)
+			continue
+		}
+
+		pluginsMutex.Lock()
+		h, _ := plugins.Load().(Plugins)
+		plugins.Store(append(h, plugin))
+		pluginsMutex.Unlock()
+
+		log.Infof("plugin %s: successfully loaded plugin", pluginName)
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,7 @@
+package plugin
+
+import (
+	"github.com/photoprism/photoprism/internal/event"
+)
+
+var log = event.Log


### PR DESCRIPTION
This PR provides the infrastructure for registering PhotoPrism plugins.

Currently the plugin system provides hooks into the following internals:

- `indexing`: Allowing to run different tagging and face detection algorithms or adding and modifying media metadata.

Fore more information consult the README in the [plugin package](https://github.com/kvalev/photoprism/tree/79ce2b9/internal/plugin/README.md)

related to https://github.com/photoprism/photoprism/issues/117, https://github.com/photoprism/photoprism/issues/1090
