### PR TITLE
Handle exif face regions with zero embeddings

### DIFF
--- a/internal/config/cli_context.go
+++ b/internal/config/cli_context.go
@@ -58,6 +58,14 @@ func ApplyCliContext(c interface{}, ctx *cli.Context) error {
 					f := ctx.GlobalInt64(tagValue)
 					fieldValue.SetInt(f)
 				}
+			case []int, []int64:
+				if ctx.IsSet(tagValue) {
+					f := reflect.ValueOf(ctx.Int64Slice(tagValue))
+					fieldValue.Set(f)
+				} else if ctx.GlobalIsSet(tagValue) || fieldValue.Len() == 0 {
+					f := reflect.ValueOf(ctx.GlobalInt64Slice(tagValue))
+					fieldValue.Set(f)
+				}
 			case uint, uint64:
 				// Only if explicitly set or current value is empty (use default).
 				if ctx.IsSet(tagValue) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,6 +206,7 @@ func (c *Config) Propagate() {
 	face.ClusterCore = c.FaceClusterCore()
 	face.ClusterDist = c.FaceClusterDist()
 	face.MatchDist = c.FaceMatchDist()
+	face.RegionAngles = c.FaceRegionAngles()
 
 	// Set default theme and locale.
 	customize.DefaultTheme = c.DefaultTheme()

--- a/internal/config/config_faces.go
+++ b/internal/config/config_faces.go
@@ -73,3 +73,32 @@ func (c *Config) FaceMatchDist() float64 {
 
 	return c.options.FaceMatchDist
 }
+
+// FaceRegionAngles returns a sanitized list of configured rotation angles (in degrees).
+func (c *Config) FaceRegionAngles() []int64 {
+	angles := make([]int64, 0)
+
+	for _, angle := range c.options.FaceRegionAngles {
+		if angle >= 0 && angle <= 360 {
+			angles = append(angles, angle)
+		}
+	}
+
+	if len(angles) == 0 {
+		return face.RegionAngles
+	}
+
+	return angles
+}
+
+// FaceRegionAngles returns a sanitized list of configured rotation angles (in pigo format - 0 to 1).
+func (c *Config) FaceRegionAnglesPigo() []float64 {
+	angles := c.FaceRegionAngles()
+	anglesNormalized := make([]float64, len(angles))
+
+	for i, angle := range angles {
+		anglesNormalized[i] = float64(angle) / 360
+	}
+
+	return anglesNormalized
+}

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -757,6 +757,12 @@ var Flags = CliFlags{
 			Value:  face.MatchDist,
 			EnvVar: EnvVar("FACE_MATCH_DIST"),
 		}}, {
+		Flag: cli.Int64SliceFlag{
+			Name:   "face-region-angles",
+			Usage:  "rotation angles at which face detection is ran as fallback in case no embeddings can be calculated for manual face regions (0-360°)",
+			Value: (*cli.Int64Slice)(&face.RegionAngles),
+			EnvVar: EnvVar("FACE_REGION_ANGLES"),
+		}}, {
 		Flag: cli.StringFlag{
 			Name:   "pid-filename",
 			Usage:  "process id `FILE` *daemon-mode only*",

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -160,6 +159,7 @@ type Options struct {
 	FaceClusterCore       int           `yaml:"-" json:"-" flag:"face-cluster-core"`
 	FaceClusterDist       float64       `yaml:"-" json:"-" flag:"face-cluster-dist"`
 	FaceMatchDist         float64       `yaml:"-" json:"-" flag:"face-match-dist"`
+	FaceRegionAngles      []int64       `yaml:"-" json:"-" flag:"face-region-angles"`
 	PIDFilename           string        `yaml:"PIDFilename" json:"-" flag:"pid-filename"`
 	LogFilename           string        `yaml:"LogFilename" json:"-" flag:"log-filename"`
 	DetachServer          bool          `yaml:"DetachServer" json:"-" flag:"detach-server"`
@@ -239,7 +239,7 @@ func (c *Options) Load(fileName string) error {
 	}
 
 	if !fs.FileExists(fileName) {
-		return errors.New(fmt.Sprintf("%s not found", fileName))
+		return fmt.Errorf("%s not found", fileName)
 	}
 
 	yamlConfig, err := os.ReadFile(fileName)

--- a/internal/config/report.go
+++ b/internal/config/report.go
@@ -21,7 +21,7 @@ func (c *Config) Report() (rows [][]string, cols []string) {
 
 	rows = [][]string{
 		// Authentication.
-		{"auth-mode", fmt.Sprintf("%s", c.AuthMode())},
+		{"auth-mode", c.AuthMode()},
 		{"admin-user", c.AdminUser()},
 		{"admin-password", strings.Repeat("*", utf8.RuneCountInString(c.AdminPassword()))},
 		{"public", fmt.Sprintf("%t", c.Public())},
@@ -220,6 +220,8 @@ func (c *Config) Report() (rows [][]string, cols []string) {
 		{"face-cluster-core", fmt.Sprintf("%d", c.FaceClusterCore())},
 		{"face-cluster-dist", fmt.Sprintf("%f", c.FaceClusterDist())},
 		{"face-match-dist", fmt.Sprintf("%f", c.FaceMatchDist())},
+		{"face-region-angles", fmt.Sprint(c.FaceRegionAngles())},
+		{"face-region-angles-pigo", fmt.Sprint(c.FaceRegionAnglesPigo())},
 
 		// Monitoring and debugging.
 		{"enable-expvar", fmt.Sprintf("%t", c.EnableExpvar())},

--- a/internal/crop/area.go
+++ b/internal/crop/area.go
@@ -36,6 +36,11 @@ func (a Area) String() string {
 	return fmt.Sprintf("%03x%03x%03x%03x", int(a.X*1000), int(a.Y*1000), int(a.W*1000), int(a.H*1000))
 }
 
+// Scale creates a new area by scaling the current one by the given factor.
+func (a Area) Scale(factor float32) Area {
+	return NewArea(a.Name, a.X * factor, a.Y * factor, a.W * factor, a.H * factor)
+}
+
 // Thumb returns a string identifying the file and crop area to create a thumb.
 func (a Area) Thumb(fileHash string) string {
 	if len(fileHash) < 40 {

--- a/internal/crop/area.go
+++ b/internal/crop/area.go
@@ -36,11 +36,6 @@ func (a Area) String() string {
 	return fmt.Sprintf("%03x%03x%03x%03x", int(a.X*1000), int(a.Y*1000), int(a.W*1000), int(a.H*1000))
 }
 
-// Scale creates a new area by scaling the current one by the given factor.
-func (a Area) Scale(factor float32) Area {
-	return NewArea(a.Name, a.X * factor, a.Y * factor, a.W * factor, a.H * factor)
-}
-
 // Thumb returns a string identifying the file and crop area to create a thumb.
 func (a Area) Thumb(fileHash string) string {
 	if len(fileHash) < 40 {

--- a/internal/face/detector_config.go
+++ b/internal/face/detector_config.go
@@ -1,0 +1,8 @@
+package face
+
+// DetectorConfig represents face dtector config options.
+type DetectorConfig struct {
+	FindLandmarks    bool    // Flag whether face landmarks (eyes, mouth) should be computed
+	IgnoreLowQuality bool    // Flag whether low quality face detection results should be ignored.
+	Angle            float64 // Angle at which the face detection should be done. Value from 0.0 to 1.0, where 0.0 represents 0° and 1.0 - 360°.
+}

--- a/internal/face/face.go
+++ b/internal/face/face.go
@@ -152,3 +152,8 @@ func (f *Face) NoEmbedding() bool {
 
 	return f.Embeddings.Empty()
 }
+
+// OverlapAboveThreshold checks whether a face overlaps significantly with a given area.
+func (f *Face) OverlapsAboveThreshold(other crop.Area) bool {
+	return f.CropArea().OverlapPercent(other) > OverlapThresholdFloor
+}

--- a/internal/face/face.go
+++ b/internal/face/face.go
@@ -153,7 +153,7 @@ func (f *Face) NoEmbedding() bool {
 	return f.Embeddings.Empty()
 }
 
-// OverlapAboveThreshold checks whether a face overlaps significantly with a given area.
+// OverlapsAboveThreshold checks whether a face overlaps significantly with a given area.
 func (f *Face) OverlapsAboveThreshold(other crop.Area) bool {
 	return f.CropArea().OverlapPercent(other) > OverlapThresholdFloor
 }

--- a/internal/face/faces.go
+++ b/internal/face/faces.go
@@ -30,6 +30,25 @@ func (faces *Faces) AppendIfNotContains(others ...Face) {
 	}
 }
 
+// Match finds a sufficiently overlapping existing face region for a given face.
+func (faces Faces) Match(other Face) *Face {
+	cropArea := other.CropArea()
+
+	for _, f := range faces {
+		scalingFactor := float32(other.Rows) / float32(f.Rows)
+		overlap := f.CropArea().Scale(scalingFactor).OverlapPercent(cropArea)
+
+		log.Warnf("debug: scaling factor is %f between %s and %s", scalingFactor, f, other)
+		log.Warnf("debug: overlap percent %d between %s and %s", overlap, f, other)
+
+		if overlap > OverlapThresholdFloor{
+			return &f
+		}
+	}
+
+	return nil
+}
+
 // Count returns the number of faces detected.
 func (faces Faces) Count() int {
 	return len(faces)

--- a/internal/face/faces.go
+++ b/internal/face/faces.go
@@ -8,7 +8,7 @@ func (faces Faces) Contains(other Face) bool {
 	cropArea := other.CropArea()
 
 	for _, f := range faces {
-		if f.CropArea().OverlapPercent(cropArea) > OverlapThresholdFloor {
+		if f.OverlapsAboveThreshold(cropArea) {
 			return true
 		}
 	}
@@ -35,13 +35,7 @@ func (faces Faces) Match(other Face) *Face {
 	cropArea := other.CropArea()
 
 	for _, f := range faces {
-		scalingFactor := float32(other.Rows) / float32(f.Rows)
-		overlap := f.CropArea().Scale(scalingFactor).OverlapPercent(cropArea)
-
-		log.Warnf("debug: scaling factor is %f between %s and %s", scalingFactor, f, other)
-		log.Warnf("debug: overlap percent %d between %s and %s", overlap, f, other)
-
-		if overlap > OverlapThresholdFloor{
+		if f.OverlapsAboveThreshold(cropArea) {
 			return &f
 		}
 	}

--- a/internal/face/rotated.go
+++ b/internal/face/rotated.go
@@ -1,0 +1,63 @@
+package face
+
+import (
+	"github.com/disintegration/imaging"
+	"github.com/photoprism/photoprism/internal/crop"
+)
+
+// RotatedFace represents a face detected at an angle (rotated).
+type RotatedFace struct {
+	Face
+	Angle float64
+}
+
+// RotatedFaces represents a list of faces detected at an angle (rotated).
+type RotatedFaces []RotatedFace
+
+// Match finds a sufficiently overlapping existing face region for a given face.
+func (faces RotatedFaces) Match(other Face) *RotatedFace {
+	cropArea := other.CropArea()
+
+	for _, f := range faces {
+		if f.OverlapsAboveThreshold(cropArea) {
+			return &f
+		}
+	}
+
+	return nil
+}
+
+// EmbeddingsRotated computes the embeddings vector for a given angled face region.
+func (t *Net) EmbeddingsRotated(fileName string, face RotatedFace) (Embeddings, error) {
+	err := t.loadModel()
+
+	if err != nil {
+		return nil, err
+	}
+
+	img, err := crop.ImageFromThumb(fileName, face.CropArea(), CropSize, false)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// After we have cropped the face region from the image, we need to rotate it accordingly.
+	// Weirdly, rotating the cropped image by the same angle, as the face returns worse results, compared to when using binning.
+	// img = imaging.Rotate(img, face.Angle * 360, color.Transparent)
+	// The binning approach rounds the face angle to the neareast 90° angle, so that the resulting image is always rotated
+	// by one of the "standart" orientations. The bins are as follows:
+	// [0°, 45°] -> do not rotate
+	// (45°, 135°] -> rotate by 90°
+	// (135°, 225°] -> rotate by 180°
+	// (225°, 315°] -> rotate by 270°
+	// (315°, 360°] -> do not rotate
+	if face.Angle > 0.125 && face.Angle <= 0.375 {
+		img = imaging.Rotate90(img)
+	} else if face.Angle > 0.375 && face.Angle <= 0.625 {
+		img = imaging.Rotate180(img)
+	} else if face.Angle > 0.625 && face.Angle <= 0.875 {
+		img = imaging.Rotate270(img)
+	}
+
+	return t.getEmbeddings(img), nil
+}

--- a/internal/face/thresholds.go
+++ b/internal/face/thresholds.go
@@ -16,6 +16,18 @@ var MatchDist = 0.46                             // Dist offset threshold for ma
 var ClusterCore = 4                              // Min number of faces forming a cluster core.
 var SampleThreshold = 2 * ClusterCore            // Threshold for automatic clustering to start.
 
+// Rotation angles for face regions' face detection (in degrees).
+//
+// The most probable reason why an exif face region could not be detected by PhotoPrism seems to be that the face region
+// is at a weird angle. To support such angled face regions, a fallback has been added, which kicks in when no embeddings
+// can be computed for an exif face region. In this case, face detetion is ran for a list of user-configured rotation angles
+// and it's checked whether any detected face significatly overlaps with the exif face region.
+//
+// During testing the following rotation angles have been identified as good candidates: 72°, 252° and 288° (in addition to 0°).
+// However per default, the image will not be rotated, as any configured angle will cause additional computational overhead,
+// so it is left up to the user to configure meaningful values based on the photos in their collection.
+var RegionAngles = []int64{0}
+
 // QualityThreshold returns the scale adjusted quality score threshold.
 func QualityThreshold(scale int) (score float32) {
 	score = float32(ScoreThreshold)

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -372,10 +372,7 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 						log.Warnf("index: no embeddings for face region %s and file %s, will try to recover", f, logName)
 
 						// Run face detection for the image at various rotation angles and check whether there is an overlapping region
-						// Currently the image is rotated at 72°, 252° and 288° (in addition to the non-rotated version).
-						angles := []float64{0.0, 0.2, 0.7, 0.8}
-
-						for _, angle := range angles {
+						for _, angle := range ind.conf.FaceRegionAnglesPigo() {
 							log.Debugf("index: running face detection at angle %.2f", angle)
 
 							if faces, err := face.DetectAllRotated(filePath, Config().FaceSize(), angle); err != nil {

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize/english"
 	"github.com/jinzhu/gorm"
 
 	"github.com/photoprism/photoprism/internal/classify"
@@ -370,31 +371,47 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 					if embeddings.Empty() {
 						log.Warnf("index: no embeddings for face region %s and file %s, will try to recover", f, logName)
 
-						// Run face detection for the image and check whether there is an overlapping region
-						faces, err := face.DetectAll(filePath, Config().FaceSize())
-						if err != nil {
-							log.Errorf("index: %s (detecting all faces for face region %s)", err, f)
-							continue
-						}
+						// Run face detection for the image at various rotation angles and check whether there is an overlapping region
+						// Currently the image is rotated at 72°, 252° and 288° (in addition to the non-rotated version).
+						angles := []float64{0.0, 0.2, 0.7, 0.8}
 
-						if matched := faces.Match(f); matched == nil {
-							log.Warnf("index: could not match face region %s to any detected faces %s", f, faces)
-							continue
-						} else {
-							log.Debugf("index: matched %s to a detected face %s", f, matched)
+						for _, angle := range angles {
+							log.Debugf("index: running face detection at angle %.2f", angle)
 
-							matchedEmbeddings, err := ind.faceNet.Embeddings(filePath, *matched)
-							if err != nil {
-								log.Errorf("index: %s (calculating embeddings for matched face %s)", err, matched)
+							if faces, err := face.DetectAllRotated(filePath, Config().FaceSize(), angle); err != nil {
+								log.Errorf("index: %s (detecting all faces for face region %s)", err, f)
+								continue
+							} else if matched := faces.Match(f); matched != nil {
+								matchedEmbeddings, err := ind.faceNet.EmbeddingsRotated(filePath, *matched)
+								if err != nil {
+									log.Errorf("index: %s (calculating embeddings for matched face %s)", err, matched)
+									continue
+								}
+
+								log.Debugf("index: matched face %s has %s", matched, english.Plural(matchedEmbeddings.Count(), "embedding", "embeddings"))
+
+								// If the matched face does not have any embeddings, but we are working with a rotated image,
+								// we might as well try to calculate the embeddings for the original face region using the same rotation angle.
+								if matchedEmbeddings.Empty() && angle > 0.0 {
+									matchedEmbeddings, err = ind.faceNet.EmbeddingsRotated(filePath, face.RotatedFace{Face: f, Angle: angle})
+									if err != nil {
+										log.Errorf("index: %s (calculating embeddings for rotated face %s)", err, matched)
+										continue
+									}
+
+									log.Debugf("index: rotated face %s has %s", f, english.Plural(matchedEmbeddings.Count(), "embedding", "embeddings"))
+								}
+
+								if matchedEmbeddings.One() {
+									// TODO Is this enough, or should we also modify the crop area for `f` to the `matched` crop area
+									embeddings = matchedEmbeddings
+									break
+								}
+							} else {
+								log.Warnf("index: could not match face region %s to any detected faces %s", f, faces)
 								continue
 							}
-
-							// TODO Is this enough, or should we also modify the crop area for `f` to the `matched` crop area
-							embeddings = matchedEmbeddings
-							log.Debugf("index: matched face %s has %d embeddings", matched, matchedEmbeddings.Count())
 						}
-
-						// IDEA: enhance region by 10% and do a sliding window?
 					}
 
 					// Assign the embeddings to the face and add the face to the file, which will create a new marker.

--- a/internal/photoprism/index_mediafile.go
+++ b/internal/photoprism/index_mediafile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/photoprism/photoprism/internal/classify"
 	"github.com/photoprism/photoprism/internal/entity"
 	"github.com/photoprism/photoprism/internal/event"
+	"github.com/photoprism/photoprism/internal/face"
 	"github.com/photoprism/photoprism/internal/meta"
 	"github.com/photoprism/photoprism/internal/plugin"
 	"github.com/photoprism/photoprism/internal/query"
@@ -352,16 +353,48 @@ func (ind *Index) UserMediaFile(m *MediaFile, o IndexOptions, originalName, phot
 						log.Debugf("index: face region was indexed, but was not named %s", f)
 					}
 				} else {
+					filePath := FileName(file.FileRoot, file.FileName)
+
 					// Hardcode the face score, which is usually computed by facenet.
 					// Setting a higher score (>15), will mean that the face region will be used for clustering.
 					f.Score = 1
 
 					// Calculate the embeddings vector for the given face region.
-					embeddings, err := ind.faceNet.Embeddings(FileName(file.FileRoot, file.FileName), f)
+					embeddings, err := ind.faceNet.Embeddings(filePath, f)
 
 					if err != nil {
 						log.Errorf("index: %s (calculating embeddings for %s)", err, logName)
 						continue
+					}
+
+					if embeddings.Empty() {
+						log.Warnf("index: no embeddings for face region %s and file %s, will try to recover", f, logName)
+
+						// Run face detection for the image and check whether there is an overlapping region
+						faces, err := face.DetectAll(filePath, Config().FaceSize())
+						if err != nil {
+							log.Errorf("index: %s (detecting all faces for face region %s)", err, f)
+							continue
+						}
+
+						if matched := faces.Match(f); matched == nil {
+							log.Warnf("index: could not match face region %s to any detected faces %s", f, faces)
+							continue
+						} else {
+							log.Debugf("index: matched %s to a detected face %s", f, matched)
+
+							matchedEmbeddings, err := ind.faceNet.Embeddings(filePath, *matched)
+							if err != nil {
+								log.Errorf("index: %s (calculating embeddings for matched face %s)", err, matched)
+								continue
+							}
+
+							// TODO Is this enough, or should we also modify the crop area for `f` to the `matched` crop area
+							embeddings = matchedEmbeddings
+							log.Debugf("index: matched face %s has %d embeddings", matched, matchedEmbeddings.Count())
+						}
+
+						// IDEA: enhance region by 10% and do a sliding window?
 					}
 
 					// Assign the embeddings to the face and add the face to the file, which will create a new marker.


### PR DESCRIPTION
When facenet cannot compute an embeddings vector for a given exif face region, the current implementation will simply skip the region, as PhotoPrism simply cannot work with faces without embeddings.

This PR implements a fallback for such cases - run face detection for the given image, including low quality detections and check whether any of the detections significantly overlaps with the exif region. Face detection is done on the original image and not on a thumbnail in order to have as many detections as possible.

Additionally the user can configure a list of angles at which aforementioned fallback face detection should be ran. Per default, the image will not be rotated, but if the user has a lot of exif face regions at non-standard angles, a list of angles can be configured using the `PHOTOPRISM_FACE_REGION_ANGLES` environment variable. Example:

```
PHOTOPRISM_FACE_REGION_ANGLES=0,90,180,270
```

related to #59 