### PR TITLE
Improve on-demand face detection for rotated images

### DIFF
--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -21,4 +21,4 @@ services:
     deploy:
       resources:
         limits:
-          memory: 500M
+          memory: 2G

--- a/internal/face/detector.go
+++ b/internal/face/detector.go
@@ -1,15 +1,16 @@
 package face
 
 import (
+	"bytes"
 	_ "embed"
 	"fmt"
 	_ "image/jpeg"
 	"io"
-	"os"
 	"path/filepath"
 	"runtime/debug"
 	"sort"
 
+	"github.com/disintegration/imaging"
 	pigo "github.com/esimov/pigo/core"
 	"github.com/photoprism/photoprism/pkg/clean"
 	"github.com/photoprism/photoprism/pkg/fs"
@@ -139,17 +140,18 @@ func detect(fileName string, findLandmarks bool, minSize int, ignoreLowQuality b
 func (d *Detector) Detect(fileName string) (faces []pigo.Detection, params pigo.CascadeParams, err error) {
 	var srcFile io.Reader
 
-	file, err := os.Open(fileName)
-
+	img, err := imaging.Open(fileName, imaging.AutoOrientation(true))
 	if err != nil {
 		return faces, params, err
 	}
 
-	defer func(file *os.File) {
-		err = file.Close()
-	}(file)
+	buffer := &bytes.Buffer{}
+	err = imaging.Encode(buffer, img, imaging.PNG)
+	if err != nil {
+		return faces, params, err
+	}
 
-	srcFile = file
+	srcFile = buffer
 
 	src, err := pigo.DecodeImage(srcFile)
 


### PR DESCRIPTION
All images will be auto-oriented before running face detection, which will improve the on-demand results (when loading low quality faces). On-demand face detection is the only place where the original image is used and not an image thumbnail (which has been auto-rotated) and in case the original image had a non-default orientation, the on-demand face detection returned mostly garbage results.

An alternative solution would have been to use the (auto-rotated) thumbnails for on-demand face detection, but thumbnails are only good for providing high-quality faces, while the on-demand face detection needs to be a bit more flexible and return even low-quality matches (even at the expense of a lot of false positives).

related to https://github.com/kvalev/photoprism/pull/51